### PR TITLE
AMBARI-24692. Use jdk8 as default compiler version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,29 +43,26 @@ deb:
 update-version:
 	$(MAVEN_BINARY) versions:set -DnewVersion=$(new-version) -DgenerateBackupPoms=false
 
-package-jdk8:
-	$(MAVEN_BINARY) clean package -Djdk.version=1.8
+package-jdk11:
+	$(MAVEN_BINARY) clean package -Djdk.version=11
 
-install-jdk8:
-	$(MAVEN_BINARY) clean install -DskipTests -Djdk.version=1.8
+install-jdk11:
+	$(MAVEN_BINARY) clean install -DskipTests -Djdk.version=11
 
-be-jdk8:
-	$(MAVEN_BINARY) clean package -Pbe -Djdk.version=1.8
+be-jdk11:
+	$(MAVEN_BINARY) clean package -Pbe -Djdk.version=11
 
-fe-jdk8:
-	$(MAVEN_BINARY) clean package -Pfe -Djdk.version=1.8
+fe-jdk11:
+	$(MAVEN_BINARY) clean package -Pfe -Djdk.version=11
 
-test-jdk8:
-	$(MAVEN_BINARY) clean test -Djdk.version=1.8
+test-jdk11:
+	$(MAVEN_BINARY) clean test -Djdk.version=11
 
-rpm-jdk8:
-	$(MAVEN_BINARY) clean package -Dbuild-rpm -DskipTests -Djdk.version=1.8
+rpm-jdk11:
+	$(MAVEN_BINARY) clean package -Dbuild-rpm -DskipTests -Djdk.version=11
 
-deb-jdk8:
-	$(MAVEN_BINARY) clean package -Dbuild-deb -DskipTests -Djdk.version=1.8
-
-javadoc:
-	$(MAVEN_BINARY) javadoc:javadoc
+deb-jdk11:
+	$(MAVEN_BINARY) clean package -Dbuild-deb -DskipTests -Djdk.version=11
 
 docker-build:
 	$(MAVEN_BINARY) clean package docker:build -DskipTests -Dlogsearch.docker.tag=$(LOGSEARCH_BUILD_DOCKER_TAG)

--- a/Makefile
+++ b/Makefile
@@ -19,56 +19,41 @@ else
   LOGSEARCH_BUILD_DOCKER_TAG = "latest"
 endif
 
+ifeq ("$(LOGSEARCH_JDK_11)", "true")
+  LOGSEARCH_JAVA_VERSION = "11"
+else
+  LOGSEARCH_JAVA_VERSION = "1.8"
+endif
+
 package:
-	$(MAVEN_BINARY) clean package
+	$(MAVEN_BINARY) clean package -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
 
 install:
-	$(MAVEN_BINARY) clean install -DskipTests
+	$(MAVEN_BINARY) clean install -DskipTests -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
 
 be:
-	$(MAVEN_BINARY) clean package -Pbe
+	$(MAVEN_BINARY) clean package -Pbe -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
 
 fe:
-	$(MAVEN_BINARY) clean package -Pfe
+	$(MAVEN_BINARY) clean package -Pfe -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
 
 test:
-	$(MAVEN_BINARY) clean test
+	$(MAVEN_BINARY) clean test -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
 
 rpm:
-	$(MAVEN_BINARY) clean package -Dbuild-rpm -DskipTests
+	$(MAVEN_BINARY) clean package -Dbuild-rpm -DskipTests -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
 
 deb:
-	$(MAVEN_BINARY) clean package -Dbuild-deb -DskipTests
+	$(MAVEN_BINARY) clean package -Dbuild-deb -DskipTests -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
 
 update-version:
 	$(MAVEN_BINARY) versions:set -DnewVersion=$(new-version) -DgenerateBackupPoms=false
 
-package-jdk11:
-	$(MAVEN_BINARY) clean package -Djdk.version=11
-
-install-jdk11:
-	$(MAVEN_BINARY) clean install -DskipTests -Djdk.version=11
-
-be-jdk11:
-	$(MAVEN_BINARY) clean package -Pbe -Djdk.version=11
-
-fe-jdk11:
-	$(MAVEN_BINARY) clean package -Pfe -Djdk.version=11
-
-test-jdk11:
-	$(MAVEN_BINARY) clean test -Djdk.version=11
-
-rpm-jdk11:
-	$(MAVEN_BINARY) clean package -Dbuild-rpm -DskipTests -Djdk.version=11
-
-deb-jdk11:
-	$(MAVEN_BINARY) clean package -Dbuild-deb -DskipTests -Djdk.version=11
-
 docker-build:
-	$(MAVEN_BINARY) clean package docker:build -DskipTests -Dlogsearch.docker.tag=$(LOGSEARCH_BUILD_DOCKER_TAG)
+	$(MAVEN_BINARY) clean package docker:build -DskipTests -Dlogsearch.docker.tag=$(LOGSEARCH_BUILD_DOCKER_TAG) -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
 
 docker-push:
-	$(MAVEN_BINARY) clean package docker:build docker:push -DskipTests -Dlogsearch.docker.tag=$(LOGSEARCH_BUILD_DOCKER_TAG)
+	$(MAVEN_BINARY) clean package docker:build docker:push -DskipTests -Dlogsearch.docker.tag=$(LOGSEARCH_BUILD_DOCKER_TAG) -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
 
 docker-dev-start:
 	cd docker && docker-compose up -d

--- a/ambari-logsearch-logfeeder/src/main/scripts/logfeeder.sh
+++ b/ambari-logsearch-logfeeder/src/main/scripts/logfeeder.sh
@@ -80,7 +80,8 @@ else
   LOGFEEDER_GC_LOGFILE="$LOG_PATH_WITHOUT_SLASH/$LOGFEEDER_GC_LOGFILE"
 fi
 
-LOGFEEDER_GC_OPTS="-Xlog:gc*:file=$LOGFEEDER_GC_LOGFILE:time"
+LOGFEEDER_GC_OPTS="-XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:$LOGFEEDER_GC_LOGFILE"
+#LOGFEEDER_GC_OPTS="-Xlog:gc*:file=$LOGFEEDER_GC_LOGFILE:time" #TODO: check java version, use this if not JDK8 is used
 
 function print_usage() {
   cat << EOF

--- a/ambari-logsearch-logfeeder/src/main/scripts/logfeeder.sh
+++ b/ambari-logsearch-logfeeder/src/main/scripts/logfeeder.sh
@@ -80,8 +80,12 @@ else
   LOGFEEDER_GC_LOGFILE="$LOG_PATH_WITHOUT_SLASH/$LOGFEEDER_GC_LOGFILE"
 fi
 
-LOGFEEDER_GC_OPTS="-XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:$LOGFEEDER_GC_LOGFILE"
-#LOGFEEDER_GC_OPTS="-Xlog:gc*:file=$LOGFEEDER_GC_LOGFILE:time" #TODO: check java version, use this if not JDK8 is used
+java_version=$($JVM -version 2>&1 | grep 'java version' | cut -d'"' -f2 | cut -d'.' -f2)
+if [ $java_version == "8" ]; then
+  LOGFEEDER_GC_OPTS="-XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:$LOGFEEDER_GC_LOGFILE"
+else
+  LOGFEEDER_GC_OPTS="-Xlog:gc*:file=$LOGFEEDER_GC_LOGFILE:time"
+fi
 
 function print_usage() {
   cat << EOF

--- a/ambari-logsearch-server/src/main/scripts/logsearch.sh
+++ b/ambari-logsearch-server/src/main/scripts/logsearch.sh
@@ -78,7 +78,8 @@ else
   LOGSEARCH_GC_LOGFILE="$LOG_PATH_WITHOUT_SLASH/$LOGSEARCH_GC_LOGFILE"
 fi
 
-LOGSEARCH_GC_OPTS="-Xlog:gc*:file=$LOGSEARCH_GC_LOGFILE:time"
+LOGSEARCH_GC_OPTS="-XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:$LOGSEARCH_GC_LOGFILE"
+# LOGSEARCH_GC_OPTS="-Xlog:gc*:file=$LOGSEARCH_GC_LOGFILE:time" #TODO: check java version, use this if not JDK8 is used
 
 function print_usage() {
   cat << EOF

--- a/ambari-logsearch-server/src/main/scripts/logsearch.sh
+++ b/ambari-logsearch-server/src/main/scripts/logsearch.sh
@@ -78,8 +78,12 @@ else
   LOGSEARCH_GC_LOGFILE="$LOG_PATH_WITHOUT_SLASH/$LOGSEARCH_GC_LOGFILE"
 fi
 
-LOGSEARCH_GC_OPTS="-XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:$LOGSEARCH_GC_LOGFILE"
-# LOGSEARCH_GC_OPTS="-Xlog:gc*:file=$LOGSEARCH_GC_LOGFILE:time" #TODO: check java version, use this if not JDK8 is used
+java_version=$($JVM -version 2>&1 | grep 'java version' | cut -d'"' -f2 | cut -d'.' -f2)
+if [ $java_version == "8" ]; then
+  LOGSEARCH_GC_OPTS="-XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:$LOGSEARCH_GC_LOGFILE"
+else
+  LOGSEARCH_GC_OPTS="-Xlog:gc*:file=$LOGSEARCH_GC_LOGFILE:time"
+fi
 
 function print_usage() {
   cat << EOF

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     </profile>
   </profiles>
   <properties>
-    <jdk.version>11</jdk.version>
+    <jdk.version>1.8</jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <python.ver>python &gt;= 2.6</python.ver>
     <deb.python.ver>python (&gt;= 2.6)</deb.python.ver>


### PR DESCRIPTION
# What changes were proposed in this pull request?
Use JDK8 by default instead of JDK11 (also reverts some gc jvm settings because of this)
## How was this patch tested?
started on docker env

please review @kasakrisz @swagle @g-boros @adoroszlai 
