### PR TITLE
AMBARI-24802 - Logsearch: upgrade swagger-ui to 3.19.0

### DIFF
--- a/ambari-logsearch-server/pom.xml
+++ b/ambari-logsearch-server/pom.xml
@@ -538,7 +538,7 @@
     <dependency>
       <groupId>org.webjars</groupId>
       <artifactId>swagger-ui</artifactId>
-      <version>2.2.2</version>
+      <version>3.19.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.data</groupId>

--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/ApiDocStorage.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/ApiDocStorage.java
@@ -18,17 +18,20 @@
  */
 package org.apache.ambari.logsearch.common;
 
-import io.swagger.jaxrs.config.BeanConfig;
-import io.swagger.models.Swagger;
-import io.swagger.util.Yaml;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.models.Swagger;
+import io.swagger.models.auth.BasicAuthDefinition;
+import io.swagger.util.Yaml;
 
 @Named
 public class ApiDocStorage {
@@ -47,20 +50,19 @@ public class ApiDocStorage {
       public void run() {
         logger.info("Start thread to scan REST API doc from endpoints.");
         Swagger swagger = beanConfig.getSwagger();
+        swagger.addSecurityDefinition("basicAuth", new BasicAuthDefinition());
         beanConfig.configure(swagger);
         beanConfig.scanAndRead();
         setSwagger(swagger);
         try {
-          if (swagger != null) {
-            String yaml = Yaml.mapper().writeValueAsString(swagger);
-            StringBuilder b = new StringBuilder();
-            String[] parts = yaml.split("\n");
-            for (String part : parts) {
-              b.append(part);
-              b.append("\n");
-            }
-            setSwaggerYaml(b.toString());
+          String yaml = Yaml.mapper().writeValueAsString(swagger);
+          StringBuilder b = new StringBuilder();
+          String[] parts = yaml.split("\n");
+          for (String part : parts) {
+            b.append(part);
+            b.append("\n");
           }
+          setSwaggerYaml(b.toString());
         } catch (Exception e) {
           e.printStackTrace();
         }

--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/AuditLogsResource.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/AuditLogsResource.java
@@ -19,6 +19,19 @@
 
 package org.apache.ambari.logsearch.rest;
 
+import static org.apache.ambari.logsearch.doc.DocConstants.AuditOperationDescriptions.EXPORT_USER_TALBE_TO_TEXT_FILE_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.AuditOperationDescriptions.GET_AUDIT_CLUSTERS_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.AuditOperationDescriptions.GET_AUDIT_COMPONENTS_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.AuditOperationDescriptions.GET_AUDIT_LINE_GRAPH_DATA_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.AuditOperationDescriptions.GET_AUDIT_LOGS_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.AuditOperationDescriptions.GET_AUDIT_SCHEMA_FIELD_LIST_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.AuditOperationDescriptions.GET_SERVICE_LOAD_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.AuditOperationDescriptions.GET_TOP_AUDIT_RESOURCES_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.AuditOperationDescriptions.PURGE_AUDIT_LOGS_OD;
+
+import java.util.List;
+import java.util.Map;
+
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -34,11 +47,9 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import freemarker.template.TemplateException;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
 import org.apache.ambari.logsearch.common.LogSearchConstants;
 import org.apache.ambari.logsearch.common.StatusMessage;
+import org.apache.ambari.logsearch.manager.AuditLogsManager;
 import org.apache.ambari.logsearch.model.metadata.AuditFieldMetadataResponse;
 import org.apache.ambari.logsearch.model.request.impl.body.AuditBarGraphBodyRequest;
 import org.apache.ambari.logsearch.model.request.impl.body.AuditLogBodyRequest;
@@ -53,15 +64,14 @@ import org.apache.ambari.logsearch.model.request.impl.query.TopFieldAuditLogQuer
 import org.apache.ambari.logsearch.model.request.impl.query.UserExportQueryRequest;
 import org.apache.ambari.logsearch.model.response.AuditLogResponse;
 import org.apache.ambari.logsearch.model.response.BarGraphDataListResponse;
-import org.apache.ambari.logsearch.manager.AuditLogsManager;
 import org.springframework.context.annotation.Scope;
 
-import java.util.List;
-import java.util.Map;
+import freemarker.template.TemplateException;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Authorization;
 
-import static org.apache.ambari.logsearch.doc.DocConstants.AuditOperationDescriptions.*;
-
-@Api(value = "audit/logs", description = "Audit log operations")
+@Api(value = "audit/logs", description = "Audit log operations", authorizations = {@Authorization(value = "basicAuth")})
 @Path("audit/logs")
 @Named
 @Scope("request")

--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/EventHistoryResource.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/EventHistoryResource.java
@@ -19,6 +19,13 @@
 
 package org.apache.ambari.logsearch.rest;
 
+import static org.apache.ambari.logsearch.doc.DocConstants.EventHistoryOperationDescriptions.DELETE_EVENT_HISTORY_DATA_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.EventHistoryOperationDescriptions.GET_ALL_USER_NAMES_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.EventHistoryOperationDescriptions.GET_EVENT_HISTORY_DATA_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.EventHistoryOperationDescriptions.SAVE_EVENT_HISTORY_DATA_OD;
+
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.ws.rs.BeanParam;
@@ -29,19 +36,17 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
 import org.apache.ambari.logsearch.manager.EventHistoryManager;
 import org.apache.ambari.logsearch.model.request.impl.query.EventHistoryQueryRequest;
 import org.apache.ambari.logsearch.model.response.EventHistoryData;
 import org.apache.ambari.logsearch.model.response.EventHistoryDataListResponse;
 import org.springframework.context.annotation.Scope;
 
-import java.util.List;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Authorization;
 
-import static org.apache.ambari.logsearch.doc.DocConstants.EventHistoryOperationDescriptions.*;
-
-@Api(value = "history", description = "Event history operations")
+@Api(value = "history", description = "Event history operations", authorizations = {@Authorization(value = "basicAuth")})
 @Path("history")
 @Named
 @Scope("request")

--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/ServiceLogsResource.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/ServiceLogsResource.java
@@ -18,6 +18,28 @@
  */
 package org.apache.ambari.logsearch.rest;
 
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.EXPORT_TO_TEXT_FILE_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_AFTER_BEFORE_LOGS_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_AGGREGATED_INFO_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_ANY_GRAPH_COUNT_DATA_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_COMPONENTS_COUNT_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_COMPONENTS_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_COMPONENT_LIST_WITH_LEVEL_COUNT_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_HISTOGRAM_DATA_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_HOSTS_COUNT_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_HOSTS_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_HOST_LIST_BY_COMPONENT_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_HOST_LOGFILES_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_LOG_LEVELS_COUNT_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_SERVICE_CLUSTERS_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_SERVICE_LOGS_SCHEMA_FIELD_NAME_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.GET_TREE_EXTENSION_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.PURGE_LOGS_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.REQUEST_CANCEL;
+import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.SEARCH_LOGS_OD;
+
+import java.util.List;
+
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -34,11 +56,9 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-
 import org.apache.ambari.logsearch.common.LogSearchConstants;
 import org.apache.ambari.logsearch.common.StatusMessage;
+import org.apache.ambari.logsearch.manager.ServiceLogsManager;
 import org.apache.ambari.logsearch.model.metadata.FieldMetadata;
 import org.apache.ambari.logsearch.model.metadata.ServiceComponentMetadataWrapper;
 import org.apache.ambari.logsearch.model.request.impl.body.ClusterBodyRequest;
@@ -72,14 +92,13 @@ import org.apache.ambari.logsearch.model.response.HostLogFilesResponse;
 import org.apache.ambari.logsearch.model.response.NameValueDataListResponse;
 import org.apache.ambari.logsearch.model.response.NodeListResponse;
 import org.apache.ambari.logsearch.model.response.ServiceLogResponse;
-import org.apache.ambari.logsearch.manager.ServiceLogsManager;
 import org.springframework.context.annotation.Scope;
 
-import java.util.List;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Authorization;
 
-import static org.apache.ambari.logsearch.doc.DocConstants.ServiceOperationDescriptions.*;
-
-@Api(value = "service/logs", description = "Service log operations")
+@Api(value = "service/logs", description = "Service log operations", authorizations = {@Authorization(value = "basicAuth")})
 @Path("service/logs")
 @Named
 @Scope("request")

--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/ShipperConfigResource.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/ShipperConfigResource.java
@@ -49,8 +49,9 @@ import org.springframework.context.annotation.Scope;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Authorization;
 
-@Api(value = "shipper", description = "Shipper config operations")
+@Api(value = "shipper", description = "Shipper config operations", authorizations = {@Authorization(value = "basicAuth")})
 @Path("shipper")
 @Named
 @Scope("request")

--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/StatusResource.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/StatusResource.java
@@ -18,25 +18,28 @@
  */
 package org.apache.ambari.logsearch.rest;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import org.apache.ambari.logsearch.conf.global.SolrCollectionState;
-import org.springframework.context.annotation.Scope;
+import static org.apache.ambari.logsearch.doc.DocConstants.StatusOperationDescriptions.AUDIT_LOGS_STATUS_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.StatusOperationDescriptions.EVENT_HISTORY_STATUS_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.StatusOperationDescriptions.SERVICE_LOGS_STATUS_OD;
+import static org.apache.ambari.logsearch.doc.DocConstants.StatusOperationDescriptions.STATUS_OD;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import java.util.HashMap;
-import java.util.Map;
 
-import static org.apache.ambari.logsearch.doc.DocConstants.StatusOperationDescriptions.AUDIT_LOGS_STATUS_OD;
-import static org.apache.ambari.logsearch.doc.DocConstants.StatusOperationDescriptions.SERVICE_LOGS_STATUS_OD;
-import static org.apache.ambari.logsearch.doc.DocConstants.StatusOperationDescriptions.STATUS_OD;
-import static org.apache.ambari.logsearch.doc.DocConstants.StatusOperationDescriptions.EVENT_HISTORY_STATUS_OD;
+import org.apache.ambari.logsearch.conf.global.SolrCollectionState;
+import org.springframework.context.annotation.Scope;
 
-@Api(value = "status", description = "Status Operations")
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Authorization;
+
+@Api(value = "status", description = "Status Operations", authorizations = {@Authorization(value = "basicAuth")})
 @Path("status")
 @Named
 @Scope("request")

--- a/ambari-logsearch-server/src/main/resources/swagger/swagger.html
+++ b/ambari-logsearch-server/src/main/resources/swagger/swagger.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html>
-<html>
+<!-- HTML for static distribution bundle build -->
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
@@ -16,121 +15,63 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Log Search REST API</title>
-    <link rel="icon" type="image/png" href="swagger-ui/2.2.2/images/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="swagger-ui/2.2.2/images/favicon-16x16.png" sizes="16x16" />
-    <link href='swagger-ui/2.2.2/css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
-    <link href='swagger-ui/2.2.2/css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
-    <link href='swagger-ui/2.2.2/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
-    <link href='swagger-ui/2.2.2/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
-    <link href='swagger-ui/2.2.2/css/print.css' media='print' rel='stylesheet' type='text/css'/>
+    <link rel="stylesheet" type="text/css" href="swagger-ui/3.19.0/swagger-ui.css" >
+    <link rel="icon" type="image/png" href="swagger-ui/3.19.0/images/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="swagger-ui/3.19.0/images/favicon-16x16.png" sizes="16x16" />
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
 
-    <script src='swagger-ui/2.2.2/lib/object-assign-pollyfill.js' type='text/javascript'></script>
-    <script src='swagger-ui/2.2.2/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
-    <script src='swagger-ui/2.2.2/lib/jquery.slideto.min.js' type='text/javascript'></script>
-    <script src='swagger-ui/2.2.2/lib/jquery.wiggle.min.js' type='text/javascript'></script>
-    <script src='swagger-ui/2.2.2/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
-    <script src='swagger-ui/2.2.2/lib/handlebars-4.0.5.js' type='text/javascript'></script>
-    <script src='swagger-ui/2.2.2/lib/lodash.min.js' type='text/javascript'></script>
-    <script src='swagger-ui/2.2.2/lib/backbone-min.js' type='text/javascript'></script>
-    <script src='swagger-ui/2.2.2/swagger-ui.js' type='text/javascript'></script>
-    <script src='swagger-ui/2.2.2/lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
-    <script src='swagger-ui/2.2.2/lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
-    <script src='swagger-ui/2.2.2/lib/jsoneditor.min.js' type='text/javascript'></script>
-    <script src='swagger-ui/2.2.2/lib/marked.js' type='text/javascript'></script>
-    <script src='swagger-ui/2.2.2/lib/swagger-oauth.js' type='text/javascript'></script>
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
 
-    <!-- Some basic translations -->
-    <!-- <script src='lang/translator.js' type='text/javascript'></script> -->
-    <!-- <script src='lang/ru.js' type='text/javascript'></script> -->
-    <!-- <script src='lang/en.js' type='text/javascript'></script> -->
-
-    <script type="text/javascript">
-        $(function () {
-            var url = window.location.search.match(/url=([^&]+)/);
-            if (url && url.length > 1) {
-                url = decodeURIComponent(url[1]);
-            } else {
-                var urlPrefix = location.protocol +'//'+ location.hostname+(location.port ? ':'+location.port: '');
-                url = urlPrefix + "/api/v1/swagger.yaml";
-            }
-
-            hljs.configure({
-                highlightSizeThreshold: 5000
-            });
-
-            // Pre load translate...
-            if(window.SwaggerTranslator) {
-                window.SwaggerTranslator.translate();
-            }
-            window.swaggerUi = new SwaggerUi({
-                url: url,
-                dom_id: "swagger-ui-container",
-                supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
-                onComplete: function(swaggerApi, swaggerUi){
-                    if(typeof initOAuth == "function") {
-                        initOAuth({
-                            clientId: "your-client-id",
-                            clientSecret: "your-client-secret-if-required",
-                            realm: "your-realms",
-                            appName: "your-app-name",
-                            scopeSeparator: " ",
-                            additionalQueryStringParams: {}
-                        });
-                    }
-
-                    if(window.SwaggerTranslator) {
-                        window.SwaggerTranslator.translate();
-                    }
-                },
-                onFailure: function(data) {
-                    log("Unable to Load SwaggerUI");
-                },
-                docExpansion: "none",
-                jsonEditor: false,
-                defaultModelRendering: 'schema',
-                showRequestHeaders: false
-            });
-
-            function addApiKeyAuthorization(){
-                var username = encodeURIComponent($('#input_username')[0].value);
-                var password = encodeURIComponent($('#input_password')[0].value);
-                if (username && username.trim() != "" && password && password != "") {
-                    var apiKeyAuth = new SwaggerClient.PasswordAuthorization("Authorization", username, password);
-                    window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
-                    log("added authorization header: " + 'Basic ' + btoa(username + ':' + password));
-                }
-            }
-
-            $('#input_username, #input_password').change(addApiKeyAuthorization);
-
-            window.swaggerUi.load();
-
-            function log() {
-                if ('console' in window) {
-                    console.log.apply(console, arguments);
-                }
-            }
-        });
-    </script>
+      body
+      {
+        margin:0;
+        background: #fafafa;
+      }
+    </style>
 </head>
 
-<body class="swagger-section">
-<div id='header'>
-    <div class="swagger-ui-wrap">
-        <a id="logo" href="http://swagger.io">swagger</a>
-        <form id='api_selector'>
-            <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
-            <div class="input"><input placeholder="username" id="input_username" name="username" type="text" size="10"></div>
-            <div class="input"><input placeholder="password" id="input_password" name="password" type="password" size="10"></div>
-            <div class='input'><a id="explore" href="#">Explore</a></div>
-        </form>
-    </div>
-</div>
+<body>
+<div id="swagger-ui"></div>
 
-<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>
-<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+<script src="swagger-ui/3.19.0/swagger-ui-bundle.js"> </script>
+<script src="swagger-ui/3.19.0/swagger-ui-standalone-preset.js"> </script>
+<script>
+    window.onload = function() {
+
+      var urlPrefix = location.protocol +'//'+ location.hostname+(location.port ? ':'+location.port: '');
+      // Build a system
+      const ui = SwaggerUIBundle({
+        url: urlPrefix + "/api/v1/swagger.yaml",
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      })
+
+      window.ui = ui
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
# What changes were proposed in this pull request?

Upgrade swagger-ui to 3.19.0

## How was this patch tested?

Manually:
1. Start Logsearch Server in idea
2. In a browser in incognito mode navigate to the page: http://localhost:61888/docs
3. Try the APIs like `info` and `status`
4. Try to authenticate using the default logsearh admin credentials and try the APIs again