### PR TITLE
Update maven versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ deb:
 	$(MAVEN_BINARY) clean package -Dbuild-deb -DskipTests -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
 
 update-version:
-	$(MAVEN_BINARY) versions:set -DnewVersion=$(new-version) -DgenerateBackupPoms=false
+	$(MAVEN_BINARY) versions:set-property -Dproperty=revision -DnewVersion=$(new-version) -DgenerateBackupPoms=false
 
 docker-build:
 	$(MAVEN_BINARY) clean package docker:build -DskipTests -Dlogsearch.docker.tag=$(LOGSEARCH_BUILD_DOCKER_TAG) -Djdk.version=$(LOGSEARCH_JAVA_VERSION)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Log Search is a sub-project of [Apache Ambari](https://github.com/apache/ambari)
 
 ## Development
 
-Requires JDK 8 (JDK 11 is recommended)
+Requires JDK 8 (JDK 11 is recommended) and Maven 3.5.x
 
 ### Prerequisites
 

--- a/ambari-logsearch-appender/pom.xml
+++ b/ambari-logsearch-appender/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   
   <artifactId>ambari-logsearch-appender</artifactId>

--- a/ambari-logsearch-assembly/pom.xml
+++ b/ambari-logsearch-assembly/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <name>Ambari Logsearch Assembly</name>
   <url>http://maven.apache.org</url>

--- a/ambari-logsearch-config-api/pom.xml
+++ b/ambari-logsearch-config-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ambari-logsearch-config-json/pom.xml
+++ b/ambari-logsearch-config-json/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ambari-logsearch-config-local/pom.xml
+++ b/ambari-logsearch-config-local/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ambari-logsearch-config-solr/pom.xml
+++ b/ambari-logsearch-config-solr/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ambari-logsearch-config-zookeeper/pom.xml
+++ b/ambari-logsearch-config-zookeeper/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ambari-logsearch-it/pom.xml
+++ b/ambari-logsearch-it/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ambari-logsearch-log4j2-appender/pom.xml
+++ b/ambari-logsearch-log4j2-appender/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ambari-logsearch-logfeeder-container-registry/pom.xml
+++ b/ambari-logsearch-logfeeder-container-registry/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>

--- a/ambari-logsearch-logfeeder-plugin-api/pom.xml
+++ b/ambari-logsearch-logfeeder-plugin-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ambari-logsearch-logfeeder/pom.xml
+++ b/ambari-logsearch-logfeeder/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ambari-logsearch-server/pom.xml
+++ b/ambari-logsearch-server/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>ambari-logsearch-server</artifactId>

--- a/ambari-logsearch-web/pom.xml
+++ b/ambari-logsearch-web/pom.xml
@@ -18,13 +18,11 @@
   <parent>
     <artifactId>ambari-logsearch</artifactId>
     <groupId>org.apache.ambari</groupId>
-    <version>2.0.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>ambari-logsearch-web</artifactId>
   <name>Ambari Logsearch Web</name>
-  <version>2.0.0.0-SNAPSHOT</version>
-  <groupId>org.apache.ambari</groupId>
   <description>Ambari Logsearch Web</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
   <groupId>org.apache.ambari</groupId>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>ambari-logsearch</artifactId>
-  <version>2.0.0.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
-
+  <name>Ambari Logsearch Parent</name>
   <url>http://maven.apache.org</url>
   <profiles>
     <profile>
@@ -76,6 +76,7 @@
     </profile>
   </profiles>
   <properties>
+    <revision>3.0.0.0-SNAPSHOT</revision>
     <jdk.version>1.8</jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <python.ver>python &gt;= 2.6</python.ver>


### PR DESCRIPTION
# What changes were proposed in this pull request?
Define maven version in one place.
Log Search requires maven 3.5.x, from that point for dev build.(note that, and upgrade to that version)

On releng side, if they are using maven versions:set, that would override the ${revision} properties everywhere, that means, with that way, maven 3.3.9 can still build the project
## How was this patch tested?
manually with different maven commands

please review @g-boros 
