### PR TITLE
Make rule to set version is `update-version`, not `set-version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Also you can run from the IDE, but make sure all of the ambari logsearch modules
 ## Update version (for release or specific builds)
 
 ```bash
-make set-version new-version="2.8.0.0-11"
+make update-version new-version="2.8.0.0-11"
 ```
 
 ## Contributing


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix typo in README for instructions to "Update version".

```bash
$ make -n set-version new-version="2.8.0.0-11"
make: *** No rule to make target `set-version'.  Stop.
```

## How was this patch tested?

```bash
$ make -n update-version new-version="2.8.0.0-11"
mvn versions:set -DnewVersion=2.8.0.0-11 -DgenerateBackupPoms=false
```