### PR TITLE
AMBARI-24825. Log Feeder: Fix HDFS/S3 outputs

### DIFF
--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputFile.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputFile.java
@@ -98,7 +98,7 @@ public class OutputFile extends Output<LogFeederProps, InputFileMarker> {
     String outStr = null;
     CSVPrinter csvPrinter = null;
     try {
-      if (codec.equals("csv")) {
+      if ("csv".equals(codec)) {
         csvPrinter = new CSVPrinter(outWriter, CSVFormat.RFC4180);
         //TODO:
       } else {

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputHDFSFile.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputHDFSFile.java
@@ -39,6 +39,7 @@ import java.io.File;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
@@ -112,6 +113,12 @@ public class OutputHDFSFile extends Output<LogFeederProps, InputFileMarker> impl
       logSpooler.add(block);
       statMetric.value++;
     }
+  }
+
+  @Override
+  public void write(Map<String, Object> jsonObj, InputFileMarker inputMarker) throws Exception {
+    String block = LogFeederUtil.getGson().toJson(jsonObj);
+    write(block, inputMarker);
   }
 
   

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/spool/LogSpooler.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/spool/LogSpooler.java
@@ -45,8 +45,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class LogSpooler {
   
   private static final Logger logger = LogManager.getLogger(LogSpooler.class);
-  public static final long TIME_BASED_ROLLOVER_DISABLED_THRESHOLD = 0;
-  static final String fileDateFormat = "yyyy-MM-dd-HH-mm-ss";
+
+  private static final String fileDateFormat = "yyyy-MM-dd-HH-mm-ss";
+  private static final long TIME_BASED_ROLLOVER_DISABLED_THRESHOLD = 0;
 
   private String spoolDirectory;
   private String sourceFileNamePrefix;

--- a/ambari-logsearch-logfeeder/src/main/scripts/logfeeder.sh
+++ b/ambari-logsearch-logfeeder/src/main/scripts/logfeeder.sh
@@ -168,7 +168,7 @@ function start() {
   LOGFEEDER_DEBUG_PORT=${LOGFEEDER_DEBUG_PORT:-"5006"}
 
   if [ "$LOGFEEDER_DEBUG" = "true" ]; then
-    LOGFEEDER_JAVA_OPTS="$LOGFEEDER_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=$LOGFEEDER_DEBUG_PORT,server=y,suspend=$LOGFEEDER_DEBUG_SUSPEND "
+    LOGFEEDER_JAVA_OPTS="$LOGFEEDER_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=*:$LOGFEEDER_DEBUG_PORT,server=y,suspend=$LOGFEEDER_DEBUG_SUSPEND "
   fi
 
   if [ "$LOGFEEDER_SSL" = "true" ]; then

--- a/ambari-logsearch-server/src/main/scripts/logsearch.sh
+++ b/ambari-logsearch-server/src/main/scripts/logsearch.sh
@@ -149,7 +149,7 @@ function start() {
   LOGSEARCH_DEBUG_PORT=${LOGSEARCH_DEBUG_PORT:-"5005"}
 
   if [ "$LOGSEARCH_DEBUG" = "true" ]; then
-    LOGSEARCH_JAVA_OPTS="$LOGSEARCH_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=$LOGSEARCH_DEBUG_PORT,server=y,suspend=$LOGSEARCH_DEBUG_SUSPEND "
+    LOGSEARCH_JAVA_OPTS="$LOGSEARCH_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=*:$LOGSEARCH_DEBUG_PORT,server=y,suspend=$LOGSEARCH_DEBUG_SUSPEND "
   fi
 
   if [ "$LOGSEARCH_SSL" = "true" ]; then

--- a/docker/cloud-docker-compose.yml
+++ b/docker/cloud-docker-compose.yml
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+version: '3.3'
+services:
+  zookeeper:
+    image: zookeeper:${ZOOKEEPER_VERSION:-3.4.10}
+    restart: always
+    hostname: zookeeper
+    networks:
+      - logsearch-network
+    ports:
+      - 2181:2181
+    environment:
+      ZOO_MY_ID: 1
+      ZOO_SERVERS: server.1=zookeeper:2888:3888
+  solr:
+    image: solr:${SOLR_VERSION:-7.5.0}
+    restart: always
+    hostname: solr
+    ports:
+      - "8983:8983"
+    networks:
+      - logsearch-network
+    env_file:
+      - Profile
+    entrypoint:
+      - docker-entrypoint.sh
+      - solr
+      - start
+      - "-f"
+      - "-c"
+      - "-z"
+      - ${ZOOKEEPER_CONNECTION_STRING}
+  logsearch:
+    image: ambari-logsearch:v1.0
+    restart: always
+    hostname: logsearch.apache.org
+    labels:
+      logfeeder.log.type: "logsearch_server"
+    networks:
+      - logsearch-network
+    env_file:
+      - Profile
+    ports:
+      - 61888:61888
+      - 4444:4444
+      - 5005:5005
+    environment:
+      COMPONENT: logsearch
+      COMPONENT_LOG: logsearch
+      ZK_CONNECT_STRING: ${ZOOKEEPER_CONNECTION_STRING}
+      DISPLAY: $DISPLAY_MAC
+    volumes:
+      - $AMBARI_LOCATION:/root/ambari
+      - $AMBARI_LOCATION/ambari-logsearch/docker/test-logs:/root/test-logs
+      - $AMBARI_LOCATION/ambari-logsearch/docker/test-config:/root/test-config
+  logfeeder:
+    image: ambari-logsearch:v1.0
+    restart: always
+    hostname: logfeeder.apache.org
+    privileged: true
+    labels:
+      logfeeder.log.type: "logfeeder"
+    networks:
+      - logsearch-network
+    env_file:
+      - Profile
+    ports:
+      - 5006:5006
+    environment:
+      COMPONENT: logfeeder
+      COMPONENT_LOG: logfeeder
+      ZK_CONNECT_STRING: ${ZOOKEEPER_CONNECTION_STRING}
+    volumes:
+      - $AMBARI_LOCATION:/root/ambari
+      - $AMBARI_LOCATION/ambari-logsearch/docker/test-logs:/root/test-logs
+      - $AMBARI_LOCATION/ambari-logsearch/docker/test-config:/root/test-config
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /usr/local/bin/docker:/usr/local/bin/docker
+      - /var/lib/docker:/var/lib/docker
+  fakes3:
+    image: localstack/localstack
+    hostname: fakes3
+    ports:
+      - "4569:4569"
+    environment:
+      - SERVICES=s3:4569
+      - DEBUG=s3
+    networks:
+      logsearch-network:
+        aliases:
+          - testbucket.fakes3
+    env_file:
+      - Profile
+  namenode:
+    image: flokkr/hadoop-hdfs-namenode:${HADOOP_VERSION:-3.0.0}
+    hostname: namenode
+    ports:
+      - 9870:9870
+      - 9000:9000
+    env_file:
+      - Profile
+    environment:
+      ENSURE_NAMENODE_DIR: "/tmp/hadoop-hdfs/dfs/name"
+    networks:
+      - logsearch-network
+  datanode:
+    image: flokkr/hadoop-hdfs-datanode:${HADOOP_VERSION:-3.0.0}
+    links:
+      - namenode
+    env_file:
+      - Profile
+    networks:
+      - logsearch-network
+networks:
+   logsearch-network:
+      driver: bridge

--- a/docker/test-config/logfeeder/shipper-conf/output.config.json
+++ b/docker/test-config/logfeeder/shipper-conf/output.config.json
@@ -31,6 +31,44 @@
           ]
         }
       }
+    },
+    {
+      "comment": "S3 file output",
+      "is_enabled": "true",
+      "destination": "s3_file",
+      "type": "s3",
+      "s3_access_key" : "accessKey",
+      "s3_secret_key" : "secretKey",
+      "s3_bucket" : "docker-logsearch",
+      "s3_endpoint" : "http://fakes3:4569",
+      "s3_log_dir" : "/tmp",
+      "skip_logtime": "true",
+      "conditions": {
+        "fields": {
+          "rowtype": [
+            "s3"
+          ]
+        }
+      }
+    },
+    {
+      "comment": "HDFS file output",
+      "is_enabled": "true",
+      "destination": "hdfs",
+      "type": "hdfs",
+      "file_name_prefix":"service-logs-",
+      "hdfs_out_dir": "/logfeeder/$HOST/service",
+      "hdfs_host": "namenode",
+      "hdfs_port": "9000",
+      "rollover_sec":"10",
+      "skip_logtime": "true",
+      "conditions": {
+        "fields": {
+          "rowtype": [
+            "hdfs"
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
# What changes were proposed in this pull request?
currently hdfs/s3 otuputs are not working properly, they are just open an empty file, i wont do anything.

as i see all kind of logs are written to the same output, so in the future we should change the log spooler to have a local file per service log

also added a new docker compose file with hdfs and s3 as well

+ fixing issue with debug java processes (use * pattern, to make it work remotely)

## How was this patch tested?
hdfs looking good, s3 has problems with the trustmanager with jdk 10/11, i will continue to take a look on that. probably that will be only a problem with the docker env

Please review @g-boros 
