### PR TITLE
AMBARI-24826. Log Search: add kerberos docker env for development.

### DIFF
--- a/docker/bin/start.sh
+++ b/docker/bin/start.sh
@@ -41,6 +41,10 @@ function set_custom_zookeeper_address() {
 function create_logfeeder_configs() {
   mkdir /root/config/logfeeder
   cp -r /root/test-config/logfeeder/* /root/config/logfeeder/
+  if [ "$LOGFEEDER_KERBEROS_ENABLED" == "true" ]
+  then
+    cp /root/test-config/logfeeder/logfeeder-kerberos.properties /root/config/logfeeder/logfeeder.properties
+  fi
   set_custom_zookeeper_address /root/config/logfeeder/logfeeder.properties
   set_custom_zookeeper_address /root/config/logfeeder/shipper-conf/output.config.json
 }
@@ -49,11 +53,15 @@ function create_logsearch_configs() {
   mkdir -p /root/config/logsearch
   cp /root/test-config/logsearch/log4j2.yml /root/config/logsearch/
   cp /root/test-config/logsearch/logsearch-env.sh /root/config/logsearch/
+  cp /root/test-config/logsearch/logsearch_jaas.conf /root/config/logsearch/
   cp $LOGSEARCH_SERVER_PATH/conf/user_pass.json /root/config/logsearch/user_pass.json
   cp $LOGSEARCH_SERVER_PATH/conf/roles.json /root/config/logsearch/roles.json
   if [ "$LOGSEARCH_HTTPS_ENABLED" == "true" ]
   then
     cp /root/test-config/logsearch/logsearch-https.properties /root/config/logsearch/logsearch.properties
+  elif [ "$LOGSEARCH_KERBEROS_ENABLED" == "true" ]
+  then
+    cp /root/test-config/logsearch/logsearch-kerberos.properties /root/config/logsearch/logsearch.properties
   else
     cp /root/test-config/logsearch/logsearch.properties /root/config/logsearch/logsearch.properties
   fi

--- a/docker/kerberos/generate-keytabs.sh
+++ b/docker/kerberos/generate-keytabs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+kadmin.local -q "addprinc -randkey nn/namenode.example.com@EXAMPLE.COM"
+kadmin.local -q "ktadd -k /data/nn.service.keytab nn/namenode.example.com@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey dn/datanode.example.com@EXAMPLE.COM"
+kadmin.local -q "ktadd -k /data/dn.service.keytab dn/datanode.example.com@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey zookeeper/zookeeper.example.com@EXAMPLE.COM"
+kadmin.local -q "ktadd -k /data/zookeeper.service.keytab zookeeper/zookeeper.example.com@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey solr/solr.example.com@EXAMPLE.COM"
+kadmin.local -q "ktadd -k /data/solr.service.keytab solr/solr.example.com@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey logsearch/logsearch.example.com@EXAMPLE.COM"
+kadmin.local -q "ktadd -k /data/logsearch.service.keytab logsearch/logsearch.example.com@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey logfeeder/logfeeder.example.com@EXAMPLE.COM"
+kadmin.local -q "ktadd -k /data/logfeeder.service.keytab logfeeder/logfeeder.example.com@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey HTTP/krb5.example.com@EXAMPLE.COM"
+kadmin.local -q "ktadd -k /data/http.service.keytab HTTP/krb5.example.com@EXAMPLE.COM"

--- a/docker/kerberos/krb5.conf
+++ b/docker/kerberos/krb5.conf
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+[logging]
+default = FILE:/var/log/krb5libs.log
+kdc = FILE:/var/log/krb5kdc.log
+admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+ dns_lookup_realm = false
+ ticket_lifetime = 24h
+ renew_lifetime = 7d
+ forwardable = true
+ rdns = false
+ default_realm = EXAMPLE.COM
+
+[realms]
+ EXAMPLE.COM = {
+  kdc = krb5.example.com
+  admin_server = krb5.example.com
+ }
+
+[domain_realm]
+ .example.com = EXAMPLE.COM
+ example.com = EXAMPLE.COM

--- a/docker/krb5-docker-compose.yml
+++ b/docker/krb5-docker-compose.yml
@@ -26,6 +26,9 @@ services:
     volumes:
     - "/tmp/kerberos:/data"
     - "./kerberos/generate-keytabs.sh:/root/keytab.generate"
+    ports:
+    - 11749:749
+    - 1188:88
   zookeeper:
     image: zookeeper:${ZOOKEEPER_VERSION:-3.4.10}
     restart: always
@@ -41,7 +44,7 @@ services:
       ZOO_MY_ID: 1
       ZOO_SERVERS: server.1=zookeeper:2888:3888
     volumes:
-      - "/tmp/kerberos:/data"
+      - "/tmp/kerberos:/krb5-data"
       - "./kerberos/krb5.conf:/etc/krb5.conf"
   solr:
     image: solr:${SOLR_VERSION:-7.5.0}
@@ -64,9 +67,14 @@ services:
     - "-c"
     - "-z"
     - zookeeper.example.com:2181
+    environment:
+      SOLR_HOST: solr.example.com
+      SOLR_AUTH_TYPE: "kerberos"
+      SOLR_AUTHENTICATION_OPTS: "-DauthenticationPlugin=org.apache.solr.security.KerberosPlugin -Djava.security.auth.login.config=/solr_jaas.conf -Dsolr.kerberos.principal=HTTP/krb5.example.com@EXAMPLE.COM -Dsolr.kerberos.keytab=/krb5-data/http.service.keytab -Dsolr.kerberos.cookie.domain=example.com "
     volumes:
-      - "/tmp/kerberos:/data"
+      - "/tmp/kerberos:/krb5-data"
       - "./kerberos/krb5.conf:/etc/krb5.conf"
+      - "./test-config/solr/solr_jaas.conf:/solr_jaas.conf"
   logsearch:
     image: ambari-logsearch:v1.0
     restart: always
@@ -85,6 +93,7 @@ services:
     - 4444:4444
     - 5005:5005
     environment:
+      LOGSEARCH_KERBEROS_ENABLED: "true"
       COMPONENT: logsearch
       COMPONENT_LOG: logsearch
       ZK_CONNECT_STRING: zookeeper.example.com:2181
@@ -93,7 +102,7 @@ services:
     - $AMBARI_LOCATION:/root/ambari
     - $AMBARI_LOCATION/ambari-logsearch/docker/test-logs:/root/test-logs
     - $AMBARI_LOCATION/ambari-logsearch/docker/test-config:/root/test-config
-    - "/tmp/kerberos:/data"
+    - "/tmp/kerberos:/krb5-data"
     - "./kerberos/krb5.conf:/etc/krb5.conf"
   logfeeder:
     image: ambari-logsearch:v1.0
@@ -115,6 +124,7 @@ services:
       COMPONENT: logfeeder
       COMPONENT_LOG: logfeeder
       ZK_CONNECT_STRING: zookeeper.example.com:2181
+      LOGFEEDER_KERBEROS_ENABLED: "true"
     volumes:
     - $AMBARI_LOCATION:/root/ambari
     - $AMBARI_LOCATION/ambari-logsearch/docker/test-logs:/root/test-logs
@@ -122,7 +132,7 @@ services:
     - /var/run/docker.sock:/var/run/docker.sock
     - /usr/local/bin/docker:/usr/local/bin/docker
     - /var/lib/docker:/var/lib/docker
-    - "/tmp/kerberos:/data"
+    - "/tmp/kerberos:/krb5-data"
     - "./kerberos/krb5.conf:/etc/krb5.conf"
   namenode:
     image: flokkr/hadoop-hdfs-namenode:${HADOOP_VERSION:-3.0.0}
@@ -140,7 +150,7 @@ services:
         aliases:
         - namenode.example.com
     volumes:
-    - "/tmp/kerberos:/data"
+    - "/tmp/kerberos:/krb5-data"
     - "./kerberos/krb5.conf:/etc/krb5.conf"
   datanode:
     image: flokkr/hadoop-hdfs-datanode:${HADOOP_VERSION:-3.0.0}
@@ -154,7 +164,7 @@ services:
         aliases:
         - datanode.example.com
     volumes:
-    - "/tmp/kerberos:/data"
+    - "/tmp/kerberos:/krb5-data"
     - "./kerberos/krb5.conf:/etc/krb5.conf"
 networks:
   logsearch-network:

--- a/docker/krb5-docker-compose.yml
+++ b/docker/krb5-docker-compose.yml
@@ -1,0 +1,161 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+version: '3.3'
+services:
+  krb5:
+    image: elek/krb5
+    container_name: krb5
+    restart: always
+    hostname: krb5.example.com
+    networks:
+      logsearch-network:
+        aliases:
+        - krb5.example.com
+    volumes:
+    - "/tmp/kerberos:/data"
+    - "./kerberos/generate-keytabs.sh:/root/keytab.generate"
+  zookeeper:
+    image: zookeeper:${ZOOKEEPER_VERSION:-3.4.10}
+    restart: always
+    container_name: zookeeper
+    hostname: zookeeper.example.com
+    networks:
+      logsearch-network:
+        aliases:
+          - zookeeper.example.com
+    ports:
+    - 2181:2181
+    environment:
+      ZOO_MY_ID: 1
+      ZOO_SERVERS: server.1=zookeeper:2888:3888
+    volumes:
+      - "/tmp/kerberos:/data"
+      - "./kerberos/krb5.conf:/etc/krb5.conf"
+  solr:
+    image: solr:${SOLR_VERSION:-7.5.0}
+    restart: always
+    container_name: solr
+    hostname: solr.example.com
+    ports:
+    - "8983:8983"
+    networks:
+      logsearch-network:
+        aliases:
+        - solr.example.com
+    env_file:
+    - Profile
+    entrypoint:
+    - docker-entrypoint.sh
+    - solr
+    - start
+    - "-f"
+    - "-c"
+    - "-z"
+    - zookeeper.example.com:2181
+    volumes:
+      - "/tmp/kerberos:/data"
+      - "./kerberos/krb5.conf:/etc/krb5.conf"
+  logsearch:
+    image: ambari-logsearch:v1.0
+    restart: always
+    hostname: logsearch.apache.org
+    container_name: logsearch
+    labels:
+      logfeeder.log.type: "logsearch_server"
+    networks:
+      logsearch-network:
+        aliases:
+        - logsearch.example.com
+    env_file:
+    - Profile
+    ports:
+    - 61888:61888
+    - 4444:4444
+    - 5005:5005
+    environment:
+      COMPONENT: logsearch
+      COMPONENT_LOG: logsearch
+      ZK_CONNECT_STRING: zookeeper.example.com:2181
+      DISPLAY: $DISPLAY_MAC
+    volumes:
+    - $AMBARI_LOCATION:/root/ambari
+    - $AMBARI_LOCATION/ambari-logsearch/docker/test-logs:/root/test-logs
+    - $AMBARI_LOCATION/ambari-logsearch/docker/test-config:/root/test-config
+    - "/tmp/kerberos:/data"
+    - "./kerberos/krb5.conf:/etc/krb5.conf"
+  logfeeder:
+    image: ambari-logsearch:v1.0
+    restart: always
+    hostname: logfeeder.example.com
+    container_name: logfeeder
+    privileged: true
+    labels:
+      logfeeder.log.type: "logfeeder"
+    networks:
+      logsearch-network:
+        aliases:
+        - logfeeder.example.com
+    env_file:
+    - Profile
+    ports:
+    - 5006:5006
+    environment:
+      COMPONENT: logfeeder
+      COMPONENT_LOG: logfeeder
+      ZK_CONNECT_STRING: zookeeper.example.com:2181
+    volumes:
+    - $AMBARI_LOCATION:/root/ambari
+    - $AMBARI_LOCATION/ambari-logsearch/docker/test-logs:/root/test-logs
+    - $AMBARI_LOCATION/ambari-logsearch/docker/test-config:/root/test-config
+    - /var/run/docker.sock:/var/run/docker.sock
+    - /usr/local/bin/docker:/usr/local/bin/docker
+    - /var/lib/docker:/var/lib/docker
+    - "/tmp/kerberos:/data"
+    - "./kerberos/krb5.conf:/etc/krb5.conf"
+  namenode:
+    image: flokkr/hadoop-hdfs-namenode:${HADOOP_VERSION:-3.0.0}
+    hostname: namenode.example.com
+    container_name: namenode
+    ports:
+    - 9870:9870
+    - 9000:9000
+    env_file:
+    - Profile
+    environment:
+      ENSURE_NAMENODE_DIR: "/tmp/hadoop-hdfs/dfs/name"
+    networks:
+      logsearch-network:
+        aliases:
+        - namenode.example.com
+    volumes:
+    - "/tmp/kerberos:/data"
+    - "./kerberos/krb5.conf:/etc/krb5.conf"
+  datanode:
+    image: flokkr/hadoop-hdfs-datanode:${HADOOP_VERSION:-3.0.0}
+    container_name: datanode
+    links:
+    - namenode
+    env_file:
+    - Profile
+    networks:
+      logsearch-network:
+        aliases:
+        - datanode.example.com
+    volumes:
+    - "/tmp/kerberos:/data"
+    - "./kerberos/krb5.conf:/etc/krb5.conf"
+networks:
+  logsearch-network:
+    driver: bridge

--- a/docker/logsearch-docker.sh
+++ b/docker/logsearch-docker.sh
@@ -85,6 +85,12 @@ LOGSEARCH_SOLR_SSL_ENABLED=false
 GENERATE_KEYSTORE_AT_START=false
 SOLR_HOST=solr
 KNOX=false
+
+HADOOP_USER_NAME=root
+CORE-SITE.XML_fs.default.name=hdfs://namenode:9000
+CORE-SITE.XML_fs.defaultFS=hdfs://namenode:9000
+HDFS-SITE.XML_dfs.namenode.rpc-address=namenode:9000
+HDFS-SITE.XML_dfs.replication=1
 EOF
     echo "'Profile' file has been created. Check it out before starting Log Search. ($sdir/Profile)"
     exit

--- a/docker/start-kerb-env.sh
+++ b/docker/start-kerb-env.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+docker-compose -f krb5-docker-compose.yml kill
+docker-compose -f krb5-docker-compose.yml up -d krb5
+docker-compose -f krb5-docker-compose.yml exec krb5 /root/keytab.generate
+docker-compose -f krb5-docker-compose.yml up -d zookeeper solr datanode namenode logsearch logfeeder

--- a/docker/test-config/logfeeder/logfeeder-env.sh
+++ b/docker/test-config/logfeeder/logfeeder-env.sh
@@ -43,3 +43,8 @@ export LOGFEEDER_TRUSTSTORE_LOCATION=/root/config/ssl/logsearch.trustStore.jks
 export LOGFEEDER_TRUSTSTORE_PASSWORD=bigdata
 export LOGFEEDER_TRUSTSTORE_TYPE=jks
 
+if [ "$LOGFEEDER_KERBEROS_ENABLED" == "true" ]
+then
+  export LOGFEEDER_JAVA_OPTS="$LOGFEEDER_JAVA_OPTS -Djava.security.auth.login.config=/root/config/logfeeder/logfeeder_jaas.conf -Dsolr.httpclient.builder.factory=org.apache.solr.client.solrj.impl.Krb5HttpClientBuilder"
+fi
+

--- a/docker/test-config/logfeeder/logfeeder-kerberos.properties
+++ b/docker/test-config/logfeeder/logfeeder-kerberos.properties
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cluster.name=CL1
+logfeeder.checkpoint.folder=/root/checkpoints
+logfeeder.metrics.collector.hosts=
+logfeeder.config.dir=/root/config/logfeeder/shipper-conf/
+logfeeder.config.files=shipper-conf/global.config.json,\
+  shipper-conf/output.config.json
+logfeeder.log.filter.enable=true
+logfeeder.solr.config.interval=5
+logfeeder.solr.zk_connect_string=localhost:9983
+logfeeder.cache.enabled=true
+logfeeder.cache.size=100
+logfeeder.cache.key.field=log_message
+logfeeder.cache.dedup.interval=1000
+logfeeder.cache.last.dedup.enabled=true
+logsearch.config.zk_connect_string=localhost:9983
+logfeeder.include.default.level=FATAL,ERROR,WARN,INFO,DEBUG,TRACE,UNKNOWN
+logfeeder.docker.registry.enabled=true
+logfeeder.solr.core.config.name=history
+
+logfeeder.solr.kerberos.enabled=true
+logfeeder.solr.jaas.file=/root/config/logfeeder/logfeeder_jaas.conf

--- a/docker/test-config/logfeeder/logfeeder_jaas.conf
+++ b/docker/test-config/logfeeder/logfeeder_jaas.conf
@@ -1,0 +1,8 @@
+Client {
+ com.sun.security.auth.module.Krb5LoginModule required
+ useKeyTab=true
+ storeKey=true
+ useTicketCache=false
+ keyTab="/krb5-data/logfeeder.service.keytab"
+ principal="logfeeder/logfeeder.example.com@EXAMPLE.COM";
+};

--- a/docker/test-config/logsearch/logsearch-env.sh
+++ b/docker/test-config/logsearch/logsearch-env.sh
@@ -38,3 +38,8 @@ export LOGSEARCH_KEYSTORE_LOCATION=/etc/ambari-logsearch-portal/conf/keys/logsea
 export LOGSEARCH_KEYSTORE_TYPE=jks
 export LOGSEARCH_TRUSTSTORE_LOCATION=/etc/ambari-logsearch-portal/conf/keys/logsearch.jks
 export LOGSEARCH_TRUSTSTORE_TYPE=jks
+
+if [ "$LOGSEARCH_KERBEROS_ENABLED" == "true" ]
+then
+  export LOGSEARCH_JAVA_OPTS="$LOGSEARCH_JAVA_OPTS -Djava.security.auth.login.config=/root/config/logsearch/logsearch_jaas.conf -Dsolr.httpclient.builder.factory=org.apache.solr.client.solrj.impl.Krb5HttpClientBuilder"
+fi

--- a/docker/test-config/logsearch/logsearch-kerberos.properties
+++ b/docker/test-config/logsearch/logsearch-kerberos.properties
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+logsearch.solr.zk_connect_string=localhost:9983
+
+# Service Logs
+logsearch.solr.collection.service.logs=hadoop_logs
+
+logsearch.service.logs.split.interval.mins=15
+logsearch.collection.service.logs.numshards=3
+logsearch.collection.service.logs.replication.factor=2
+
+# Audit logs
+logsearch.solr.audit.logs.zk_connect_string=localhost:9983
+logsearch.solr.collection.audit.logs=audit_logs
+logsearch.solr.audit.logs.url=
+
+logsearch.audit.logs.split.interval.mins=15
+logsearch.collection.audit.logs.numshards=3
+logsearch.collection.audit.logs.replication.factor=2
+
+logsearch.solr.config_set.folder=/root/ambari/ambari-logsearch/ambari-logsearch-server/target/package/conf/solr_configsets
+logsearch.solr.audit.logs.config_set.folder=/root/ambari/ambari-logsearch/ambari-logsearch-server/target/package/conf/solr_configsets
+
+# History logs
+logsearch.solr.collection.history=history
+logsearch.solr.history.config.name=history
+logsearch.collection.history.replication.factor=1
+
+# Metrics
+logsearch.solr.metrics.collector.hosts=
+logsearch.solr.jmx.port=18886
+
+# logsearch-admin.json
+logsearch.auth.file.enabled=true
+logsearch.login.credentials.file=user_pass.json
+
+logsearch.authr.file.enabled=false
+
+logsearch.auth.ldap.enabled=false
+logsearch.auth.simple.enabled=false
+logsearch.auth.external_auth.enabled=false
+
+logsearch.protocol=http
+
+logsearch.config.zk_connect_string=localhost:9983
+
+logsearch.solr.kerberos.enabled=true
+logsearch.solr.jaas.file=/root/config/logsearch/logsearch_jaas.conf

--- a/docker/test-config/logsearch/logsearch_jaas.conf
+++ b/docker/test-config/logsearch/logsearch_jaas.conf
@@ -1,0 +1,8 @@
+Client {
+ com.sun.security.auth.module.Krb5LoginModule required
+ useKeyTab=true
+ storeKey=true
+ useTicketCache=false
+ keyTab="/krb5-data/logsearch.service.keytab"
+ principal="logsearch/logsearch.example.com@EXAMPLE.COM";
+};

--- a/docker/test-config/solr/solr_jaas.conf
+++ b/docker/test-config/solr/solr_jaas.conf
@@ -1,0 +1,8 @@
+Client {
+ com.sun.security.auth.module.Krb5LoginModule required
+ useKeyTab=true
+ storeKey=true
+ useTicketCache=false
+ keyTab="/krb5-data/solr.service.keytab"
+ principal="solr/solr.example.com@EXAMPLE.COM";
+};


### PR DESCRIPTION
# What changes were proposed in this pull request?
add krb5 container, and create keytabs for services.

that is the first part of the change, it only creates the keytabs, and set up the network. next step will be o provide right configs to start services with spnego/kerberos

## How was this patch tested?
with docker env

Please review @g-boros 
