### PR TITLE
AMBARI-24851 - Logsearch: debug mode using java 8 and 11

### DIFF
--- a/ambari-logsearch-server/src/main/scripts/logsearch.sh
+++ b/ambari-logsearch-server/src/main/scripts/logsearch.sh
@@ -150,10 +150,11 @@ function start() {
 
   if [ "$LOGSEARCH_DEBUG" = "true" ]; then
     if [ $java_version == "8" ]; then
-      LOGSEARCH_JAVA_OPTS="$LOGSEARCH_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=$LOGSEARCH_DEBUG_PORT,server=y,suspend=$LOGSEARCH_DEBUG_SUSPEND "
+      LOGSEARCH_DEBUG_ADDRESS=$LOGSEARCH_DEBUG_PORT
     else
-      LOGSEARCH_JAVA_OPTS="$LOGSEARCH_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=*:$LOGSEARCH_DEBUG_PORT,server=y,suspend=$LOGSEARCH_DEBUG_SUSPEND "
+      LOGSEARCH_DEBUG_ADDRESS="*:$LOGSEARCH_DEBUG_PORT"
     fi
+    LOGSEARCH_JAVA_OPTS="$LOGSEARCH_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=$LOGSEARCH_DEBUG_ADDRESS,server=y,suspend=$LOGSEARCH_DEBUG_SUSPEND "
   fi
 
   if [ "$LOGSEARCH_SSL" = "true" ]; then

--- a/ambari-logsearch-server/src/main/scripts/logsearch.sh
+++ b/ambari-logsearch-server/src/main/scripts/logsearch.sh
@@ -149,7 +149,11 @@ function start() {
   LOGSEARCH_DEBUG_PORT=${LOGSEARCH_DEBUG_PORT:-"5005"}
 
   if [ "$LOGSEARCH_DEBUG" = "true" ]; then
-    LOGSEARCH_JAVA_OPTS="$LOGSEARCH_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=*:$LOGSEARCH_DEBUG_PORT,server=y,suspend=$LOGSEARCH_DEBUG_SUSPEND "
+    if [ $java_version == "8" ]; then
+      LOGSEARCH_JAVA_OPTS="$LOGSEARCH_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=$LOGSEARCH_DEBUG_PORT,server=y,suspend=$LOGSEARCH_DEBUG_SUSPEND "
+    else
+      LOGSEARCH_JAVA_OPTS="$LOGSEARCH_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=*:$LOGSEARCH_DEBUG_PORT,server=y,suspend=$LOGSEARCH_DEBUG_SUSPEND "
+    fi
   fi
 
   if [ "$LOGSEARCH_SSL" = "true" ]; then


### PR DESCRIPTION
# What changes were proposed in this pull request?

Logsearch server can not be started in debug mode if Logsearch is running in an Ambari managed cluster using java 8

## How was this patch tested?

manually:
1. Start Logsearch using the docker env and attach a debugger

2. Deploy Ambari and Logsearch, enable debug mode in logsearch-env and attach a debugger 
