### PR TITLE
AMBARI-24851 - ADDENDUM Logsearch: debug mode using java 8 and 11

### DIFF
--- a/ambari-logsearch-logfeeder/src/main/scripts/logfeeder.sh
+++ b/ambari-logsearch-logfeeder/src/main/scripts/logfeeder.sh
@@ -168,7 +168,12 @@ function start() {
   LOGFEEDER_DEBUG_PORT=${LOGFEEDER_DEBUG_PORT:-"5006"}
 
   if [ "$LOGFEEDER_DEBUG" = "true" ]; then
-    LOGFEEDER_JAVA_OPTS="$LOGFEEDER_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=*:$LOGFEEDER_DEBUG_PORT,server=y,suspend=$LOGFEEDER_DEBUG_SUSPEND "
+    if [ $java_version == "8" ]; then
+      LOGFEEDER_DEBUG_ADDRESS=$LOGFEEDER_DEBUG_PORT
+    else
+      LOGFEEDER_DEBUG_ADDRESS="*:$LOGFEEDER_DEBUG_PORT"
+    fi
+    LOGFEEDER_JAVA_OPTS="$LOGFEEDER_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=$LOGFEEDER_DEBUG_ADDRESS,server=y,suspend=$LOGFEEDER_DEBUG_SUSPEND "
   fi
 
   if [ "$LOGFEEDER_SSL" = "true" ]; then


### PR DESCRIPTION
# What changes were proposed in this pull request?

like #15 for Logfeeder 

## How was this patch tested?
manually:
adding the following line to `logfeeder-env` template
```
export LOGFEEDER_DEBUG=true 
```