### PR TITLE
AMBARI-24875. Log Search: cannot build sub-modules separately.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node/
 .hg
 .hgignore
 .hgtags
+.flattened-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,30 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <configuration>
+          <updatePomFile>true</updatePomFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
        <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>rpm-maven-plugin</artifactId>


### PR DESCRIPTION
# What changes were proposed in this pull request?
Use flatten plugin for building the project, as without that the sub-modules cannot be built separately (because of revision property)

## How was this patch tested?
i could build any submodule
