### PR TITLE
AMBARI-24833. Use seconds instead of minutes for cloud log threshold

### DIFF
--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogFeederConstants.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogFeederConstants.java
@@ -117,7 +117,7 @@ public class LogFeederConstants {
   public static final String CLOUD_STORAGE_BASE_PATH = "logfeeder.cloud.storage.base.path";
 
   public static final String CLOUD_ROLLOVER_ARCHIVE_LOCATION = "logfeeder.cloud.rollover.archive.base.dir";
-  public static final String CLOUD_ROLLOVER_THRESHOLD_TIME_MIN = "logfeeder.cloud.rollover.threshold.min";
+  public static final String CLOUD_ROLLOVER_THRESHOLD_TIME_SECONDS = "logfeeder.cloud.rollover.threshold.min";
   public static final String CLOUD_ROLLOVER_THRESHOLD_TIME_SIZE = "logfeeder.cloud.rollover.threshold.size";
   public static final String CLOUD_ROLLOVER_MAX_BACKUP_FILES = "logfeeder.cloud.rollover.max.files";
   public static final String CLOUD_ROLLOVER_THRESHOLD_TIME_SIZE_UNIT = "logfeeder.cloud.rollover.threshold.size.unit";

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/output/RolloverConfig.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/output/RolloverConfig.java
@@ -37,14 +37,14 @@ public class RolloverConfig {
   private String rolloverArchiveBaseDir;
 
   @LogSearchPropertyDescription(
-    name = LogFeederConstants.CLOUD_ROLLOVER_THRESHOLD_TIME_MIN,
+    name = LogFeederConstants.CLOUD_ROLLOVER_THRESHOLD_TIME_SECONDS,
     description = "Rollover cloud log files after an interval (minutes)",
-    examples = {"1"},
-    defaultValue = "60",
+    examples = {"60"},
+    defaultValue = "3600",
     sources = {LogFeederConstants.LOGFEEDER_PROPERTIES_FILE}
   )
-  @Value("${"+ LogFeederConstants.CLOUD_ROLLOVER_THRESHOLD_TIME_MIN + ":60}")
-  private int rolloverThresholdTimeMins;
+  @Value("${"+ LogFeederConstants.CLOUD_ROLLOVER_THRESHOLD_TIME_SECONDS + ":3600}")
+  private int rolloverThresholdTimeSeconds;
 
   @LogSearchPropertyDescription(
     name = LogFeederConstants.CLOUD_ROLLOVER_THRESHOLD_TIME_SIZE,
@@ -116,12 +116,12 @@ public class RolloverConfig {
   @Value("${"+ LogFeederConstants.CLOUD_ROLLOVER_ON_STARTUP + ":false}")
   private boolean rolloverOnStartup;
 
-  public int getRolloverThresholdTimeMins() {
-    return rolloverThresholdTimeMins;
+  public int getRolloverThresholdTimeSeconds() {
+    return rolloverThresholdTimeSeconds;
   }
 
-  public void setRolloverThresholdTimeMins(int rolloverThresholdTimeMins) {
-    this.rolloverThresholdTimeMins = rolloverThresholdTimeMins;
+  public void setRolloverThresholdTimeSeconds(int rolloverThresholdTimeSeconds) {
+    this.rolloverThresholdTimeSeconds = rolloverThresholdTimeSeconds;
   }
 
   public Integer getRolloverMaxBackupFiles() {

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/output/RolloverConfig.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/output/RolloverConfig.java
@@ -38,7 +38,7 @@ public class RolloverConfig {
 
   @LogSearchPropertyDescription(
     name = LogFeederConstants.CLOUD_ROLLOVER_THRESHOLD_TIME_SECONDS,
-    description = "Rollover cloud log files after an interval (minutes)",
+    description = "Rollover cloud log files after an interval (seconds)",
     examples = {"60"},
     defaultValue = "3600",
     sources = {LogFeederConstants.LOGFEEDER_PROPERTIES_FILE}

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/CloudStorageLoggerFactory.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/CloudStorageLoggerFactory.java
@@ -78,7 +78,7 @@ public class CloudStorageLoggerFactory {
     String rolloverSize = logFeederProps.getRolloverConfig().getRolloverSize().toString() + logFeederProps.getRolloverConfig().getRolloverSizeFormat();
     SizeBasedTriggeringPolicy sizeBasedTriggeringPolicy = SizeBasedTriggeringPolicy.createPolicy(rolloverSize);
     CustomTimeBasedTriggeringPolicy customTimeBasedTriggeringPolicy = CustomTimeBasedTriggeringPolicy
-      .createPolicy(String.valueOf(logFeederProps.getRolloverConfig().getRolloverThresholdTimeMins()));
+      .createPolicy(String.valueOf(logFeederProps.getRolloverConfig().getRolloverThresholdTimeSeconds()));
 
     final CompositeTriggeringPolicy compositeTriggeringPolicy;
 

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/CustomTimeBasedTriggeringPolicy.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/CustomTimeBasedTriggeringPolicy.java
@@ -34,17 +34,17 @@ import java.util.concurrent.TimeUnit;
 @Plugin(name = "CustomTimeBasedTriggeringPolicy", category = Core.CATEGORY_NAME, printObject = true)
 public final class CustomTimeBasedTriggeringPolicy extends AbstractTriggeringPolicy {
 
-  private final long intervalMin;
+  private final long intervalSeconds;
 
   private RollingFileManager manager;
   private long nextRolloverMillis;
 
-  private CustomTimeBasedTriggeringPolicy(final long intervalMin) {
-    this.intervalMin = intervalMin;
+  private CustomTimeBasedTriggeringPolicy(final long intervalSeconds) {
+    this.intervalSeconds = intervalSeconds;
   }
 
-  public long getIntervalMin() {
-    return this.intervalMin;
+  public long getIntervalSeconds() {
+    return this.intervalSeconds;
   }
 
   @Override
@@ -53,7 +53,7 @@ public final class CustomTimeBasedTriggeringPolicy extends AbstractTriggeringPol
     long fileTime = this.manager.getFileTime();
     long actualDate = System.currentTimeMillis();
     long diff = actualDate - fileTime;
-    long intervalMillis = TimeUnit.MINUTES.toMillis(this.intervalMin);
+    long intervalMillis = TimeUnit.SECONDS.toMillis(this.intervalSeconds);
     if (diff > intervalMillis) {
       this.nextRolloverMillis = actualDate;
     } else {
@@ -69,7 +69,7 @@ public final class CustomTimeBasedTriggeringPolicy extends AbstractTriggeringPol
     } else {
       long nowMillis = event.getTimeMillis();
       if (nowMillis >= this.nextRolloverMillis) {
-        this.nextRolloverMillis = nowMillis + TimeUnit.MINUTES.toMillis(this.intervalMin);
+        this.nextRolloverMillis = nowMillis + TimeUnit.SECONDS.toMillis(this.intervalSeconds);
         return true;
       } else {
         return false;
@@ -78,8 +78,8 @@ public final class CustomTimeBasedTriggeringPolicy extends AbstractTriggeringPol
   }
 
   @PluginFactory
-  public static CustomTimeBasedTriggeringPolicy createPolicy(@PluginAttribute("intervalMins") final String intervalMins) {
-    return new CustomTimeBasedTriggeringPolicy(Long.parseLong(intervalMins));
+  public static CustomTimeBasedTriggeringPolicy createPolicy(@PluginAttribute("intervalSeconds") final String intervalSeconds) {
+    return new CustomTimeBasedTriggeringPolicy(Long.parseLong(intervalSeconds));
   }
 
 }

--- a/ambari-logsearch-logfeeder/src/main/resources/logfeeder.properties
+++ b/ambari-logsearch-logfeeder/src/main/resources/logfeeder.properties
@@ -53,7 +53,7 @@ logfeeder.cloud.storage.bucket=logfeeder
 logfeeder.cloud.storage.bucket.bootstrap=true
 
 logfeeder.cloud.rollover.archive.base.dir=target/tmp
-logfeeder.cloud.rollover.threshold.min=1000
+logfeeder.cloud.rollover.threshold.seconds=120
 logfeeder.cloud.rollover.threshold.size=1
 logfeeder.cloud.rollover.threshold.size.unit=K
 logfeeder.cloud.rollover.immediate.flush=true


### PR DESCRIPTION
# What changes were proposed in this pull request?
Use seconds instead of minutes for cloud log threshold

it will be more usable for ambari stack (smart configs)

## How was this patch tested?
waiting for UTs
