### PR TITLE
AMBARI-24833. Use clustername and hostname in cloud log archive dir

### DIFF
--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/CloudStorageLoggerFactory.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/CloudStorageLoggerFactory.java
@@ -21,6 +21,7 @@ package org.apache.ambari.logfeeder.output.cloud;
 import org.apache.ambari.logfeeder.common.LogFeederConstants;
 import org.apache.ambari.logfeeder.conf.LogFeederProps;
 import org.apache.ambari.logfeeder.plugin.input.Input;
+import org.apache.ambari.logfeeder.util.LogFeederUtil;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -58,8 +59,9 @@ public class CloudStorageLoggerFactory {
     Configuration config = loggerContext.getConfiguration();
     String destination = logFeederProps.getCloudStorageDestination().getText();
     String baseDir = logFeederProps.getRolloverConfig().getRolloverArchiveBaseDir();
-    String activeLogDir = Paths.get(baseDir, destination, ACTIVE_FOLDER, type).toFile().getAbsolutePath();
-    String archiveLogDir = Paths.get(baseDir, destination, ARCHIVED_FOLDER, type).toFile().getAbsolutePath();
+    String clusterHostnameBaseDir = Paths.get(baseDir, destination, logFeederProps.getClusterName(), LogFeederUtil.hostName).toFile().getAbsolutePath();
+    String activeLogDir = Paths.get(clusterHostnameBaseDir, ACTIVE_FOLDER, type).toFile().getAbsolutePath();
+    String archiveLogDir = Paths.get(clusterHostnameBaseDir, ARCHIVED_FOLDER, type).toFile().getAbsolutePath();
 
     boolean useGzip = logFeederProps.getRolloverConfig().isUseGzip();
     final String archiveFilePattern;

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/CloudStorageLoggerFactory.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/CloudStorageLoggerFactory.java
@@ -57,8 +57,8 @@ public class CloudStorageLoggerFactory {
     String type = input.getLogType().replace(LogFeederConstants.CLOUD_PREFIX, "");
     String uniqueThreadName = input.getThread().getName();
     Configuration config = loggerContext.getConfiguration();
-    String destination = logFeederProps.getCloudStorageDestination().getText();
     String baseDir = logFeederProps.getRolloverConfig().getRolloverArchiveBaseDir();
+    String destination = logFeederProps.getCloudStorageDestination().getText();
     String clusterHostnameBaseDir = Paths.get(baseDir, destination, logFeederProps.getClusterName(), LogFeederUtil.hostName).toFile().getAbsolutePath();
     String activeLogDir = Paths.get(clusterHostnameBaseDir, ACTIVE_FOLDER, type).toFile().getAbsolutePath();
     String archiveLogDir = Paths.get(clusterHostnameBaseDir, ARCHIVED_FOLDER, type).toFile().getAbsolutePath();

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/CloudStorageUploader.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/CloudStorageUploader.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Collection;
 
 /**
@@ -74,10 +75,11 @@ public class CloudStorageUploader extends Thread {
    */
   void doUpload() {
     try {
-      final String archiveLogDir = String.join(File.separator, logFeederProps.getRolloverConfig().getRolloverArchiveBaseDir(), uploaderType, "archived");
-      if (new File(archiveLogDir).exists()) {
+      final File archiveLogDir = Paths.get(logFeederProps.getRolloverConfig().getRolloverArchiveBaseDir(),
+        uploaderType, clusterName, hostName, "archived").toFile();
+      if (archiveLogDir.exists()) {
         String[] extensions = {"log", "json", "gz"};
-        Collection<File> filesToUpload = FileUtils.listFiles(new File(archiveLogDir), extensions, true);
+        Collection<File> filesToUpload = FileUtils.listFiles(archiveLogDir, extensions, true);
         if (filesToUpload.isEmpty()) {
           logger.debug("Not found any files to upload.");
         } else {


### PR DESCRIPTION
# What changes were proposed in this pull request?
Use hostname + cluster name as well in archive dir (to make it work properly with mounts)

## How was this patch tested?
FT manually with docker env

please review @g-boros 
