### PR TITLE
AMBARI-24833. Let logfeeder.properties override core-site configs.

### DIFF
--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/upload/HDFSS3UploadClient.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/upload/HDFSS3UploadClient.java
@@ -57,6 +57,7 @@ public class HDFSS3UploadClient extends AbstractS3CloudClient implements UploadC
     conf.set("fs.s3a.endpoint", s3OutputConfig.getEndpoint());
     conf.set("fs.s3a.path.style.access", String.valueOf(s3OutputConfig.isPathStyleAccess()));
     conf.set("fs.s3a.multiobjectdelete.enable", String.valueOf(s3OutputConfig.isMultiobjectDeleteEnable()));
+    LogFeederHDFSUtil.overrideFileSystemConfigs(logFeederProps, conf);
     this.fs = LogFeederHDFSUtil.buildFileSystem(conf);
   }
 

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/upload/HDFSUploadClient.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/upload/HDFSUploadClient.java
@@ -84,6 +84,7 @@ public class HDFSUploadClient implements UploadClient {
       }
     }
     logger.info("HDFS client - will use '{}' permission for uploaded files", hdfsOutputConfig.getHdfsFilePermissions());
+    LogFeederHDFSUtil.overrideFileSystemConfigs(logFeederProps, configuration);
     this.fs = LogFeederHDFSUtil.buildFileSystem(configuration);
   }
 

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/util/LogFeederHDFSUtil.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/util/LogFeederHDFSUtil.java
@@ -19,7 +19,10 @@
 package org.apache.ambari.logfeeder.util;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
 
+import org.apache.ambari.logfeeder.conf.LogFeederProps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -92,6 +95,22 @@ public class LogFeederHDFSUtil {
         fileSystem.close();
       } catch (IOException e) {
         logger.error(e.getLocalizedMessage(), e.getCause());
+      }
+    }
+  }
+
+  /**
+   * Override Hadoop configuration object based on logfeeder.properties configurations (with keys that starts with "fs." or "hadoop.*")
+   * @param logFeederProps global property holder
+   * @param configuration hadoop configuration holder
+   */
+  public static void overrideFileSystemConfigs(LogFeederProps logFeederProps, Configuration configuration) {
+    Properties properties = logFeederProps.getProperties();
+    for (Map.Entry<Object, Object> prop : properties.entrySet()) {
+      String propertyName = prop.getKey().toString();
+      if (propertyName.startsWith("fs.")) {
+        logger.info("Override {} configuration (by logfeeder.properties)", propertyName);
+        configuration.set(propertyName, prop.getValue().toString());
       }
     }
   }

--- a/ambari-logsearch-logfeeder/src/main/resources/logfeeder.properties
+++ b/ambari-logsearch-logfeeder/src/main/resources/logfeeder.properties
@@ -68,3 +68,5 @@ logfeeder.s3.access.key=MyAccessKey
 logfeeder.s3.object.acl=public-read
 logfeeder.s3.path.style.access=true
 logfeeder.s3.multiobject.delete.enable=false
+
+fs.s3a.acl.default=PublicReadWrite


### PR DESCRIPTION
# What changes were proposed in this pull request?
core site configs can be override by logfeeder.properties.
It can be useful if no core-site.xml available on a host
## How was this patch tested?
FT: manually
