### PR TITLE
AMBARI-24833. Do not open FS on main thread.

### DIFF
--- a/ambari-logsearch-config-local/src/main/java/org/apache/ambari/logsearch/config/local/LogSearchConfigLogFeederLocal.java
+++ b/ambari-logsearch-config-local/src/main/java/org/apache/ambari/logsearch/config/local/LogSearchConfigLogFeederLocal.java
@@ -111,7 +111,7 @@ public class LogSearchConfigLogFeederLocal extends LogSearchConfigLocal implemen
       } catch (Exception e) {
         final String errorMessage;
         if (tries < 3) {
-          errorMessage = String.format("Cannot parse input config: %s, will retry in a few seconds again (tries: %s)", inputConfig, String.valueOf(tries));
+          errorMessage = String.format("Cannot parse input config: '%s', will retry in a few seconds again (tries: %s)", inputConfig, String.valueOf(tries));
           logger.error(errorMessage, e);
           try {
             Thread.sleep(2000);

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogFeederConstants.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogFeederConstants.java
@@ -108,7 +108,7 @@ public class LogFeederConstants {
   public static final String CLOUD_STORAGE_MODE = "logfeeder.cloud.storage.mode";
   public static final String CLOUD_STORAGE_DESTINATION = "logfeeder.cloud.storage.destination";
   public static final String CLOUD_STORAGE_UPLOAD_ON_SHUTDOWN = "logfeeder.cloud.storage.upload.on.shutdown";
-  public static final String CLOUD_STORAGE_UPLOADER_TIMEOUT_MINTUES = "logfeeder.cloud.storage.uploader.timeout.minutes";
+  public static final String CLOUD_STORAGE_UPLOADER_TIMEOUT_MINUTUES = "logfeeder.cloud.storage.uploader.timeout.minutes";
   public static final String CLOUD_STORAGE_UPLOADER_INTERVAL_SECONDS = "logfeeder.cloud.storage.uploader.interval.seconds";
   public static final String CLOUD_STORAGE_BUCKET = "logfeeder.cloud.storage.bucket";
   public static final String CLOUD_STORAGE_BUCKET_BOOTSTRAP = "logfeeder.cloud.storage.bucket.bootstrap";

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogFeederConstants.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/common/LogFeederConstants.java
@@ -108,6 +108,7 @@ public class LogFeederConstants {
   public static final String CLOUD_STORAGE_MODE = "logfeeder.cloud.storage.mode";
   public static final String CLOUD_STORAGE_DESTINATION = "logfeeder.cloud.storage.destination";
   public static final String CLOUD_STORAGE_UPLOAD_ON_SHUTDOWN = "logfeeder.cloud.storage.upload.on.shutdown";
+  public static final String CLOUD_STORAGE_UPLOADER_TIMEOUT_MINTUES = "logfeeder.cloud.storage.uploader.timeout.minutes";
   public static final String CLOUD_STORAGE_UPLOADER_INTERVAL_SECONDS = "logfeeder.cloud.storage.uploader.interval.seconds";
   public static final String CLOUD_STORAGE_BUCKET = "logfeeder.cloud.storage.bucket";
   public static final String CLOUD_STORAGE_BUCKET_BOOTSTRAP = "logfeeder.cloud.storage.bucket.bootstrap";

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederProps.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederProps.java
@@ -252,13 +252,13 @@ public class LogFeederProps implements LogFeederProperties {
   private Integer cloudStorageUploaderIntervalSeconds;
 
   @LogSearchPropertyDescription(
-    name = LogFeederConstants.CLOUD_STORAGE_UPLOADER_TIMEOUT_MINTUES,
+    name = LogFeederConstants.CLOUD_STORAGE_UPLOADER_TIMEOUT_MINUTUES,
     description = "Timeout value for uploading task to cloud storage in minutes.",
     examples = {"10"},
     defaultValue = "60",
     sources = {LogFeederConstants.LOGFEEDER_PROPERTIES_FILE}
   )
-  @Value("${" + LogFeederConstants.CLOUD_STORAGE_UPLOADER_TIMEOUT_MINTUES + ":60}")
+  @Value("${" + LogFeederConstants.CLOUD_STORAGE_UPLOADER_TIMEOUT_MINUTUES + ":60}")
   private Integer cloudStorageUploaderTimeoutMinutes;
 
   @LogSearchPropertyDescription(

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederProps.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederProps.java
@@ -252,6 +252,16 @@ public class LogFeederProps implements LogFeederProperties {
   private Integer cloudStorageUploaderIntervalSeconds;
 
   @LogSearchPropertyDescription(
+    name = LogFeederConstants.CLOUD_STORAGE_UPLOADER_TIMEOUT_MINTUES,
+    description = "Timeout value for uploading task to cloud storage in minutes.",
+    examples = {"10"},
+    defaultValue = "60",
+    sources = {LogFeederConstants.LOGFEEDER_PROPERTIES_FILE}
+  )
+  @Value("${" + LogFeederConstants.CLOUD_STORAGE_UPLOADER_TIMEOUT_MINTUES + ":60}")
+  private Integer cloudStorageUploaderTimeoutMinutes;
+
+  @LogSearchPropertyDescription(
     name = LogFeederConstants.CLOUD_STORAGE_USE_HDFS_CLIENT,
     description = "Use hdfs client with cloud connectors instead of the core clients for shipping data to cloud storage",
     examples = {"true"},
@@ -497,6 +507,14 @@ public class LogFeederProps implements LogFeederProperties {
 
   public void setCloudStorageUploaderIntervalSeconds(Integer cloudStorageUploaderIntervalSeconds) {
     this.cloudStorageUploaderIntervalSeconds = cloudStorageUploaderIntervalSeconds;
+  }
+
+  public Integer getCloudStorageUploaderTimeoutMinutes() {
+    return cloudStorageUploaderTimeoutMinutes;
+  }
+
+  public void setCloudStorageUploaderTimeoutMinutes(Integer cloudStorageUploaderTimeoutMinutes) {
+    this.cloudStorageUploaderTimeoutMinutes = cloudStorageUploaderTimeoutMinutes;
   }
 
   public boolean isUseCloudHdfsClient() {

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/CloudStorageOutput.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/CloudStorageOutput.java
@@ -129,7 +129,7 @@ public class CloudStorageOutput extends Output<LogFeederProps, InputMarker> {
     uploader.interrupt();
     if (logFeederProps.isCloudStorageUploadOnShutdown()) {
       logger.info("Do last upload before shutdown.");
-      uploader.doUpload();
+      uploader.doUpload(2); // hard-coded 2 minutes timeout on shutdown
     }
   }
 

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/upload/HDFSUploadClient.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/upload/HDFSUploadClient.java
@@ -30,6 +30,8 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * HDFS client that uses core-site.xml file from the classpath to load the configuration.
  * Can connect to S3 / GCS / WASB / ADLS if the core-site.xml is configured to use one of those cloud storages
@@ -44,7 +46,7 @@ public class HDFSUploadClient implements UploadClient {
   private final boolean externalHdfs;
   private final HdfsOutputConfig hdfsOutputConfig;
   private final FsPermission fsPermission;
-  private Configuration configuration;
+  private final AtomicReference<Configuration> configurationRef = new AtomicReference<>();
 
   public HDFSUploadClient(HdfsOutputConfig hdfsOutputConfig, boolean externalHdfs) {
     this.hdfsOutputConfig = hdfsOutputConfig;
@@ -54,6 +56,7 @@ public class HDFSUploadClient implements UploadClient {
 
   @Override
   public void init(LogFeederProps logFeederProps) {
+    final Configuration configuration;
     if (externalHdfs) {
       configuration = LogFeederHDFSUtil.buildHdfsConfiguration(hdfsOutputConfig.getHdfsHost(), String.valueOf(hdfsOutputConfig.getHdfsPort()), "hdfs");
       logger.info("Using external HDFS client as core-site.xml is not located on the classpath.");
@@ -83,12 +86,13 @@ public class HDFSUploadClient implements UploadClient {
       }
     }
     logger.info("HDFS client - will use '{}' permission for uploaded files", hdfsOutputConfig.getHdfsFilePermissions());
-    LogFeederHDFSUtil.overrideFileSystemConfigs(logFeederProps, configuration);
+    configurationRef.set(configuration);
+    LogFeederHDFSUtil.overrideFileSystemConfigs(logFeederProps, configurationRef.get());
   }
 
   @Override
   public void upload(String source, String target) throws Exception {
-    final FileSystem fs = LogFeederHDFSUtil.buildFileSystem(configuration);
+    final FileSystem fs = LogFeederHDFSUtil.buildFileSystem(configurationRef.get());
     LogFeederHDFSUtil.copyFromLocal(source, target, fs, true, true, this.fsPermission);
   }
 

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/upload/HDFSUploadClient.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/cloud/upload/HDFSUploadClient.java
@@ -44,7 +44,7 @@ public class HDFSUploadClient implements UploadClient {
   private final boolean externalHdfs;
   private final HdfsOutputConfig hdfsOutputConfig;
   private final FsPermission fsPermission;
-  private FileSystem fs;
+  private Configuration configuration;
 
   public HDFSUploadClient(HdfsOutputConfig hdfsOutputConfig, boolean externalHdfs) {
     this.hdfsOutputConfig = hdfsOutputConfig;
@@ -54,7 +54,6 @@ public class HDFSUploadClient implements UploadClient {
 
   @Override
   public void init(LogFeederProps logFeederProps) {
-    final Configuration configuration;
     if (externalHdfs) {
       configuration = LogFeederHDFSUtil.buildHdfsConfiguration(hdfsOutputConfig.getHdfsHost(), String.valueOf(hdfsOutputConfig.getHdfsPort()), "hdfs");
       logger.info("Using external HDFS client as core-site.xml is not located on the classpath.");
@@ -85,17 +84,16 @@ public class HDFSUploadClient implements UploadClient {
     }
     logger.info("HDFS client - will use '{}' permission for uploaded files", hdfsOutputConfig.getHdfsFilePermissions());
     LogFeederHDFSUtil.overrideFileSystemConfigs(logFeederProps, configuration);
-    this.fs = LogFeederHDFSUtil.buildFileSystem(configuration);
   }
 
   @Override
   public void upload(String source, String target) throws Exception {
+    final FileSystem fs = LogFeederHDFSUtil.buildFileSystem(configuration);
     LogFeederHDFSUtil.copyFromLocal(source, target, fs, true, true, this.fsPermission);
   }
 
   @Override
   public void close() {
-    LogFeederHDFSUtil.closeFileSystem(fs);
   }
 
 }


### PR DESCRIPTION
# What changes were proposed in this pull request?
Do not create FS on main thread, on hybrid mode, it can block the main thread so the solr output will stop working.
also adding a timeout for cloud log uploader (for uploading + fs creation)

## How was this patch tested?
stopped localstack/hdfs in hybrid mode

Please review @g-boros 
