### PR TITLE
AMBARI-24935. Log Search: enable/disable request audit logging for jetty

### DIFF
--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchHttpConfig.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchHttpConfig.java
@@ -67,6 +67,16 @@ public class LogSearchHttpConfig {
   @Value("${logsearch.session.timeout:30}")
   private Integer sessionTimeout;
 
+  @LogSearchPropertyDescription(
+    name = "logsearch.jetty.access.log.enabled",
+    description = "Enable jetty access logs",
+    examples = {"true"},
+    defaultValue = "false",
+    sources = {LOGSEARCH_PROPERTIES_FILE}
+  )
+  @Value("${logsearch.jetty.access.log.enabled:false}")
+  private boolean useAccessLogs;
+
   public String getProtocol() {
     return protocol;
   }
@@ -97,5 +107,13 @@ public class LogSearchHttpConfig {
 
   public void setSessionTimeout(Integer sessionTimeout) {
     this.sessionTimeout = sessionTimeout;
+  }
+
+  public boolean isUseAccessLogs() {
+    return useAccessLogs;
+  }
+
+  public void setUseAccessLogs(boolean useAccessLogs) {
+    this.useAccessLogs = useAccessLogs;
   }
 }

--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchWebServerCustomizer.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchWebServerCustomizer.java
@@ -22,7 +22,6 @@ import org.apache.ambari.logsearch.configurer.SslConfigurer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.Property;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.NCSARequestLog;
 import org.eclipse.jetty.server.ServerConnector;

--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchWebServerCustomizer.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchWebServerCustomizer.java
@@ -19,7 +19,12 @@
 package org.apache.ambari.logsearch.conf;
 
 import org.apache.ambari.logsearch.configurer.SslConfigurer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Property;
 import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.NCSARequestLog;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
@@ -29,14 +34,15 @@ import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 
 import static org.apache.ambari.logsearch.common.LogSearchConstants.LOGSEARCH_SESSION_ID;
 
 @Component
 public class LogSearchWebServerCustomizer implements WebServerFactoryCustomizer<JettyServletWebServerFactory> {
-
-  private static final Integer SESSION_TIMEOUT = 30;
 
   @Inject
   private ServerProperties serverProperties;
@@ -51,6 +57,7 @@ public class LogSearchWebServerCustomizer implements WebServerFactoryCustomizer<
   public void customize(JettyServletWebServerFactory webServerFactory) {
     serverProperties.getServlet().getSession().setTimeout(Duration.ofMinutes(logSearchHttpConfig.getSessionTimeout()));
     serverProperties.getServlet().getSession().getCookie().setName(LOGSEARCH_SESSION_ID);
+
     if ("https".equals(logSearchHttpConfig.getProtocol())) {
       sslConfigurer.ensureStorePasswords();
       sslConfigurer.loadKeystore();
@@ -62,6 +69,20 @@ public class LogSearchWebServerCustomizer implements WebServerFactoryCustomizer<
       });
     } else {
       webServerFactory.setPort(logSearchHttpConfig.getHttpPort());
+    }
+    if (logSearchHttpConfig.isUseAccessLogs()) {
+      webServerFactory.addServerCustomizers((JettyServerCustomizer) server -> {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        Configuration configuration = context.getConfiguration();
+        String logDir = configuration.getStrSubstitutor().getVariableResolver().lookup("log-path");
+        String logFileNameSuffix = "logsearch-jetty-yyyy_mm_dd.request.log";
+        String logFileName = logDir == null ? logFileNameSuffix : Paths.get(logDir, logFileNameSuffix).toString();
+        NCSARequestLog requestLog = new NCSARequestLog(logFileName);
+        requestLog.setAppend(true);
+        requestLog.setExtended(false);
+        requestLog.setLogTimeZone("GMT");
+        server.setRequestLog(requestLog);
+      });
     }
   }
 }

--- a/ambari-logsearch-server/src/main/resources/log4j2.yml
+++ b/ambari-logsearch-server/src/main/resources/log4j2.yml
@@ -52,8 +52,8 @@ Configutation:
       DefaultRollOverStrategy:
         max: 10
     - name: AuditFile_Appender
-      fileName: ${log-path}/logsearch-audit.json
-      filePattern: "logsearch-audit.json.%d{yyyy-MM-dd-hh-mm}.gz"
+      fileName: ${log-path}/logsearch-solr-audit.json
+      filePattern: "logsearch-solr-audit.json.%d{yyyy-MM-dd-hh-mm}.gz"
       ignoreExceptions: false
       LogSearchJsonLayout:
         charset: UTF-8
@@ -63,8 +63,8 @@ Configutation:
       DefaultRollOverStrategy:
         max: 10
     - name: PerformanceFile_Appender
-      fileName: ${log-path}/logsearch-performance.json
-      filePattern: "logsearch-perf.json.%d{yyyy-MM-dd-hh-mm}.gz"
+      fileName: ${log-path}/logsearch-solr-performance.json
+      filePattern: "logsearch-solr-performance.json.%d{yyyy-MM-dd-hh-mm}.gz"
       LogSearchJsonLayout:
         charset: UTF-8
       Policies:


### PR DESCRIPTION
# What changes were proposed in this pull request?
Add jetty access logs for Log Search.
Try to gather log-path property from log4j2 config, and use that as the directory for the jetty access log

## How was this patch tested?
Manually

please review @g-boros 
