### PR TITLE
[AMBARI-24945] [Log Search UI] Handling null or undefined value in log's level property.

### DIFF
--- a/ambari-logsearch-web/src/app/components/log-level/log-level.component.html
+++ b/ambari-logsearch-web/src/app/components/log-level/log-level.component.html
@@ -15,4 +15,4 @@
   limitations under the License.
 -->
 <i class="fa {{cssClass}}"></i>
-{{logEntry.level}}
+{{('levels.' + (logEntry.level || 'unknown').toLowerCase()) | translate}}

--- a/ambari-logsearch-web/src/app/components/log-level/log-level.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/log-level/log-level.component.spec.ts
@@ -14,11 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {DebugElement} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import {LogLevelComponent} from './log-level.component';
-import {By} from '@angular/platform-browser';
+import { LogLevelComponent } from './log-level.component';
+import { By } from '@angular/platform-browser';
+
+import { TranslationModules } from '@app/test-config.spec';
 
 describe('LogLevelComponent', () => {
   let component: LogLevelComponent;
@@ -37,6 +39,9 @@ describe('LogLevelComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [
+        ...TranslationModules
+      ],
       declarations: [ LogLevelComponent ]
     })
     .compileComponents();

--- a/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.html
+++ b/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.html
@@ -95,7 +95,7 @@
                   {{log.logtime | amTz: timeZone | amDateFormat: timeFormat}}
                 </time>
               </td>
-              <td *ngIf="isColumnDisplayed('level')" [ngClass]="'log-level ' + log.level.toLowerCase()">
+              <td *ngIf="isColumnDisplayed('level')" [ngClass]="'log-level ' + (log.level ? log.level.toLowerCase() : '')">
                 <log-level [logEntry]="log"></log-level>
               </td>
               <td *ngIf="isColumnDisplayed('type')" [ngClass]="'log-type'">
@@ -138,7 +138,7 @@
                 <dropdown-button iconClass="fa fa-ellipsis-v action" [hideCaret]="true" [options]="logActions"
                                  [listItemArguments]="[log]" [showSelectedValue]="false"></dropdown-button>
               </div>
-              <div *ngIf="isColumnDisplayed('level')" [ngClass]="'log-level ' + log.level.toLowerCase()">
+              <div *ngIf="isColumnDisplayed('level')" [ngClass]="'log-level ' + (log.level ? log.level.toLowerCase() : '')">
                 <log-level [logEntry]="log"></log-level>
               </div>
               <div *ngIf="isColumnDisplayed('type')" [ngClass]="'log-type'" [title]="log.type">


### PR DESCRIPTION
# What changes were proposed in this pull request?

Simple edge case handling. It is a fallback solution when the `level` property is missing.

## How was this patch tested?

It was tested manually and by unit tests:
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 292 of 292 SUCCESS (9.154 secs / 9.048 secs)
✨  Done in 35.93s.
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
