### PR TITLE
AMBARI-24950 - Logsearch: use os timezone in Logfeeder

### DIFF
--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/util/DateUtil.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/util/DateUtil.java
@@ -18,31 +18,18 @@
  */
 package org.apache.ambari.logfeeder.util;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class DateUtil {
   private static final Logger logger = LogManager.getLogger(DateUtil.class);
   
   private DateUtil() {
     throw new UnsupportedOperationException();
-  }
-  
-  public static String dateToString(Date date, String dateFormat) {
-    if (date == null || dateFormat == null || dateFormat.isEmpty()) {
-      return "";
-    }
-    try {
-      SimpleDateFormat formatter = new SimpleDateFormat(dateFormat);
-      return formatter.format(date).toString();
-    } catch (Exception e) {
-      logger.error("Error in coverting dateToString  format :" + dateFormat, e);
-    }
-    return "";
   }
 
   private final static String SOLR_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";


### PR DESCRIPTION
# What changes were proposed in this pull request?

Logfeeder sets the default timezone to GMT at start up. Most service logs' logtime are in os timezone. If os timezone is set to other than UTC Logfeeder does not convert the logtime values to UTC when sending the log entry to Solr and Logsearch portal shows invalid log time values.
Fix: 
* Remove explicitly set the default time zone to GMT. This case the default time zone going to be the os time zone
Or it can be overridden by JVM option.
* Remove unused `dateToString` method.

## How was this patch tested?

Manually:
1. Deploy Ambari and a cluster: Zookeeper, Infra-Solr, Logsearch
2. Set the time zone en each node to America/Chicago: 
```timedatectl set-timezone America/Chicago```
3. Restart Amabari server/agents and all services
4. Check Ambari server log and notice that the log time values are at the new time zone in the end of the logfile while the values in the beginning are in UTC
```
grep 'State of service component' /var/log/ambari-server/ambari-server.log
2018-11-23 15:04:53,058  INFO [agent-report-processor-0] HeartbeatProcessor:647 - State of service component LOGSEARCH_SERVER of service LOGSEARCH of cluster 2 has changed from INSTALLED to STARTED at host c7401.ambari.apache.org according to STATUS_COMMAND report
2018-11-23 15:05:19,535  INFO [agent-report-processor-0] HeartbeatProcessor:647 - State of service component LOGSEARCH_LOGFEEDER of service LOGSEARCH of cluster 2 has changed from INSTALLED to STARTED at host c7401.ambari.apache.org according to STATUS_COMMAND report
2018-11-23 09:18:35,669  INFO [agent-report-processor-0] HeartbeatProcessor:647 - State of service component LOGSEARCH_SERVER of service LOGSEARCH of cluster 2 has changed from STARTED to INSTALLED at host c7401.ambari.apache.org according to STATUS_COMMAND report
2018-11-23 09:18:42,652  INFO [agent-report-processor-1] HeartbeatProcessor:647 - State of service component LOGSEARCH_LOGFEEDER of service LOGSEARCH of cluster 2 has changed from STARTED to INSTALLED at host c7402.ambari.apache.org according to STATUS_COMMAND report
```
5. Check that all ambari server log entries logtime is converted to UTC in Solr
```
{
        "log_message":"State of service component LOGSEARCH_SERVER of service LOGSEARCH of cluster 2 has changed from INSTALLED to STARTED at host c7401.ambari.apache.org according to STATUS_COMMAND report",
        "id":"606519d6-a315-4553-8f49-dda2eba7437f",
        "logtime":"2018-11-23T15:04:53.058Z"},
      {
        "log_message":"State of service component LOGSEARCH_LOGFEEDER of service LOGSEARCH of cluster 2 has changed from INSTALLED to STARTED at host c7401.ambari.apache.org according to STATUS_COMMAND report",
        "id":"97760f62-ec8b-447f-92e4-b49f616ed897",
        "logtime":"2018-11-23T15:05:19.535Z"},
      {
        "log_message":"State of service component LOGSEARCH_SERVER of service LOGSEARCH of cluster 2 has changed from STARTED to INSTALLED at host c7401.ambari.apache.org according to STATUS_COMMAND report",
        "id":"19aefe4f-ab22-43b5-a952-4bd355a0f6b3",
        "logtime":"2018-11-23T15:18:35.669Z"},
      {
        "log_message":"State of service component LOGSEARCH_LOGFEEDER of service LOGSEARCH of cluster 2 has changed from STARTED to INSTALLED at host c7402.ambari.apache.org according to STATUS_COMMAND report",
        "id":"3601f700-7272-4c38-bd7d-5d89552bdcc2",
        "logtime":"2018-11-23T15:18:42.652Z"},
```
6. Check that the logtime values are converted to the specified timezone on Logsearch portal