### PR TITLE
AMBARI-24956. Log Search: cleanup audit/service log config name prefixes

### DIFF
--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrAuditLogPropsConfig.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrAuditLogPropsConfig.java
@@ -48,9 +48,9 @@ public class SolrAuditLogPropsConfig implements SolrPropsConfig {
   )
   private String zkConnectString;
 
-  @Value("${logsearch.solr.collection.audit.logs:audit_logs}")
+  @Value("${logsearch.solr.audit.logs.collection:audit_logs}")
   @LogSearchPropertyDescription(
-    name = "logsearch.solr.collection.audit.logs",
+    name = "logsearch.solr.audit.logs.collection",
     description = "Name of Log Search audit collection.",
     examples = {"audit_logs"},
     defaultValue = "audit_logs",
@@ -58,9 +58,9 @@ public class SolrAuditLogPropsConfig implements SolrPropsConfig {
   )
   private String collection;
 
-  @Value("${logsearch.ranger.audit.logs.collection.name:}")
+  @Value("${logsearch.solr.ranger.audit.logs.collection:}")
   @LogSearchPropertyDescription(
-    name = "logsearch.ranger.audit.logs.collection.name",
+    name = "logsearch.solr.ranger.audit.logs.collection",
     description = "Name of Ranger audit collections (can be used if ranger audits managed by the same Solr which is used for Log Search).",
     examples = {"ranger_audits"},
     sources = {LOGSEARCH_PROPERTIES_FILE}
@@ -87,9 +87,9 @@ public class SolrAuditLogPropsConfig implements SolrPropsConfig {
   )
   private String aliasNameIn;
 
-  @Value("${logsearch.collection.audit.logs.numshards:1}")
+  @Value("${logsearch.solr.audit.logs.numshards:1}")
   @LogSearchPropertyDescription(
-    name = "logsearch.collection.audit.logs.numshards",
+    name = "logsearch.solr.audit.logs.numshards",
     description = "Number of Solr shards for audit collection (bootstrapping).",
     examples = {"2"},
     defaultValue = "1",
@@ -97,9 +97,9 @@ public class SolrAuditLogPropsConfig implements SolrPropsConfig {
   )
   private Integer numberOfShards;
 
-  @Value("${logsearch.collection.audit.logs.replication.factor:1}")
+  @Value("${logsearch.solr.audit.logs.replication.factor:1}")
   @LogSearchPropertyDescription(
-    name = "logsearch.collection.audit.logs.replication.factor",
+    name = "logsearch.solr.audit.logs.replication.factor",
     description = "Solr replication factor for audit collection (bootstrapping).",
     examples = {"2"},
     defaultValue = "1",

--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrMetadataPropsConfig.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrMetadataPropsConfig.java
@@ -27,9 +27,9 @@ import static org.apache.ambari.logsearch.common.LogSearchConstants.LOGSEARCH_PR
 @Configuration
 public class SolrMetadataPropsConfig extends SolrConnectionPropsConfig {
 
-  @Value("${logsearch.solr.collection.metadata:logsearch_metadata}")
+  @Value("${logsearch.solr.metadata.collection:logsearch_metadata}")
   @LogSearchPropertyDescription(
-    name = "logsearch.solr.collection.metadata",
+    name = "logsearch.solr.metadata",
     description = "Name of Log Search metadata collection.",
     examples = {"logsearch_metadata"},
     defaultValue = "logsearch_metadata",
@@ -47,19 +47,19 @@ public class SolrMetadataPropsConfig extends SolrConnectionPropsConfig {
   )
   private String configName;
 
-  @Value("${logsearch.collection.metadata.numshards:1}")
+  @Value("${logsearch.solr.metadata.numshards:2}")
   @LogSearchPropertyDescription(
-    name = "logsearch.collection.metadata.numshards",
+    name = "logsearch.solr.metadata.numshards",
     description = "Number of Solr shards for logsearch metadta collection (bootstrapping).",
-    examples = {"2"},
-    defaultValue = "1",
+    examples = {"3"},
+    defaultValue = "2",
     sources = {LOGSEARCH_PROPERTIES_FILE}
   )
   private Integer numberOfShards;
 
-  @Value("${logsearch.collection.metadata.replication.factor:2}")
+  @Value("${logsearch.solr.metadata.replication.factor:2}")
   @LogSearchPropertyDescription(
-    name = "logsearch.collection.metadata.replication.factor",
+    name = "logsearch.solr.metadata.replication.factor",
     description = "Solr replication factor for event metadata collection (bootstrapping).",
     examples = {"3"},
     defaultValue = "2",
@@ -67,9 +67,9 @@ public class SolrMetadataPropsConfig extends SolrConnectionPropsConfig {
   )
   private Integer replicationFactor;
 
-  @Value("${logsearch.schema.fields.populate.interval.mins:1}")
+  @Value("${logsearch.solr.metadata.schema.fields.populate.interval.mins:1}")
   @LogSearchPropertyDescription(
-    name = "logsearch.schema.fields.populate.interval.mins",
+    name = "logsearch.solr.metadata.schema.fields.populate.interval.mins",
     description = "Interval in minutes for populating schema fiels for metadata collections.",
     examples = {"10"},
     defaultValue = "1",
@@ -116,7 +116,6 @@ public class SolrMetadataPropsConfig extends SolrConnectionPropsConfig {
   public void setReplicationFactor(Integer replicationFactor) {
     this.replicationFactor = replicationFactor;
   }
-  
 
   public Integer getPopulateIntervalMins() {
     return populateIntervalMins;

--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrServiceLogPropsConfig.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SolrServiceLogPropsConfig.java
@@ -27,9 +27,9 @@ import static org.apache.ambari.logsearch.common.LogSearchConstants.LOGSEARCH_PR
 @Configuration
 public class SolrServiceLogPropsConfig extends SolrConnectionPropsConfig {
 
-  @Value("${logsearch.solr.collection.service.logs:hadoop_logs}")
+  @Value("${logsearch.solr.service.logs.collection:hadoop_logs}")
   @LogSearchPropertyDescription(
-    name = "logsearch.solr.collection.service.logs",
+    name = "logsearch.solr.service.logs",
     description = "Name of Log Search service log collection.",
     examples = {"hadoop_logs"},
     defaultValue = "hadoop_logs",
@@ -47,9 +47,9 @@ public class SolrServiceLogPropsConfig extends SolrConnectionPropsConfig {
   )
   private String configName;
 
-  @Value("${logsearch.collection.service.logs.numshards:1}")
+  @Value("${logsearch.solr.service.logs.numshards:1}")
   @LogSearchPropertyDescription(
-    name = "logsearch.collection.service.logs.numshards",
+    name = "logsearch.solr.service.logs.numshards",
     description = "Number of Solr shards for service log collection (bootstrapping).",
     examples = {"2"},
     defaultValue = "1",
@@ -57,9 +57,9 @@ public class SolrServiceLogPropsConfig extends SolrConnectionPropsConfig {
   )
   private Integer numberOfShards;
 
-  @Value("${logsearch.collection.service.logs.replication.factor:1}")
+  @Value("${logsearch.solr.service.logs.replication.factor:1}")
   @LogSearchPropertyDescription(
-    name = "logsearch.collection.service.logs.replication.factor",
+    name = "logsearch.solr.service.logs.replication.factor",
     description = "Solr replication factor for service log collection (bootstrapping).",
     examples = {"2"},
     defaultValue = "1",

--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/dao/SolrSchemaFieldDao.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/dao/SolrSchemaFieldDao.java
@@ -68,7 +68,7 @@ public class SolrSchemaFieldDao {
   private AuditSolrDao auditSolrDao;
   
   @Inject
-  private SolrMetadataPropsConfig solrEventHistoryPropsConfig;
+  private SolrMetadataPropsConfig solrMetadataPropsConfig;
   
   private int retryCount;
   private int skipCount;
@@ -117,9 +117,9 @@ public class SolrSchemaFieldDao {
       if (schemaResponse != null) {
         extractSchemaFieldsName(lukeResponses, schemaResponse, schemaFieldNameMap, schemaFieldTypeMap);
         logger.debug("Populate fields for collection " + solrClient.getDefaultCollection()+ " was successful, next update it after " +
-            solrEventHistoryPropsConfig.getPopulateIntervalMins() + " minutes");
+            solrMetadataPropsConfig.getPopulateIntervalMins() + " minutes");
         retryCount = 0;
-        skipCount = (solrEventHistoryPropsConfig.getPopulateIntervalMins() * 60) / RETRY_SECOND - 1;
+        skipCount = (solrMetadataPropsConfig.getPopulateIntervalMins() * 60) / RETRY_SECOND - 1;
       }
       else {
         retryCount++;

--- a/ambari-logsearch-server/src/main/resources/logsearch.properties
+++ b/ambari-logsearch-server/src/main/resources/logsearch.properties
@@ -13,18 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 logsearch.solr.zk_connect_string=localhost:2181
-logsearch.solr.collection.service.logs=hadoop_logs
-logsearch.collection.service.logs.numshards=3
-logsearch.collection.service.logs.replication.factor=2
+logsearch.solr.service.logs.collection=hadoop_logs
+logsearch.solr.service.logs.numshards=3
+logsearch.solr.service.logs.replication.factor=2
 logsearch.solr.audit.logs.zk_connect_string=localhost:2181
-logsearch.solr.collection.audit.logs=audit_logs
-logsearch.collection.audit.logs.numshards=2
-logsearch.collection.audit.logs.replication.factor=2
+logsearch.solr.audit.logs.collection=audit_logs
+logsearch.solr.audit.logs.numshards=2
+logsearch.solr.audit.logs.replication.factor=2
 logsearch.solr.config_set.folder=${LOGSEARCH_SERVER_RELATIVE_LOCATION:}src/main/configsets
 logsearch.solr.audit.logs.config_set.folder=${LOGSEARCH_SERVER_RELATIVE_LOCATION:}src/main/configsets
-logsearch.solr.collection.metadata=logsearch_metadata
-logsearch.solr.collection.config.name=logsearch_metadata
-logsearch.collection.metadata.replication.factor=1
+logsearch.solr.metadata.collection=logsearch_metadata
+logsearch.solr.metadata.config.name=logsearch_metadata
+logsearch.solr.metadata.replication.factor=1
 logsearch.auth.file.enabled=true
 logsearch.login.credentials.file=user_pass.json
 

--- a/ambari-logsearch-server/src/test/resources/logsearch.properties
+++ b/ambari-logsearch-server/src/test/resources/logsearch.properties
@@ -13,16 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+logsearch.solr.audit.logs.collection=test_audit_logs_collection
 logsearch.solr.audit.logs.config.name=test_audit_logs_config_name
-logsearch.collection.audit.logs.numshards=123
-logsearch.collection.audit.logs.replication.factor=456
-logsearch.solr.collection.audit.logs=test_audit_logs_collection
+logsearch.solr.audit.logs.numshards=123
+logsearch.solr.audit.logs.replication.factor=456
 
+logsearch.solr.service.logs.collection=test_service_logs_collection
 logsearch.solr.service.logs.config.name=test_service_logs_config_name
-logsearch.collection.service.logs.numshards=789
-logsearch.collection.service.logs.replication.factor=987
-logsearch.solr.collection.service.logs=test_service_logs_collection
-logsearch.service.logs.split.interval.mins=1
+logsearch.solr.service.logs.numshards=789
+logsearch.solr.service.logs.replication.factor=987
 
 logsearch.auth.file.enable=true
 logsearch.login.credentials.file=user_pass.json

--- a/docker/test-config/logsearch/logsearch-https.properties
+++ b/docker/test-config/logsearch/logsearch-https.properties
@@ -16,20 +16,16 @@
 logsearch.solr.zk_connect_string=localhost:9983
 
 # Service Logs
-logsearch.solr.collection.service.logs=hadoop_logs
-
-logsearch.service.logs.split.interval.mins=15
-logsearch.collection.service.logs.numshards=3
-logsearch.collection.service.logs.replication.factor=2
+logsearch.solr.service.logs.collection=hadoop_logs
+logsearch.solr.service.logs.numshards=3
+logsearch.solr.service.logs.replication.factor=2
 
 # Audit logs
 logsearch.solr.audit.logs.zk_connect_string=localhost:9983
-logsearch.solr.collection.audit.logs=audit_logs
+logsearch.solr.audit.logs.collection=audit_logs
 logsearch.solr.audit.logs.url=
-
-logsearch.audit.logs.split.interval.mins=15
-logsearch.collection.audit.logs.numshards=3
-logsearch.collection.audit.logs.replication.factor=2
+logsearch.solr.audit.logs.numshards=3
+logsearch.solr.audit.logs.replication.factor=2
 
 logsearch.solr.config_set.folder=/root/ambari/ambari-logsearch/ambari-logsearch-server/target/package/conf/solr_configsets
 logsearch.solr.audit.logs.config_set.folder=/root/ambari/ambari-logsearch/ambari-logsearch-server/target/package/conf/solr_configsets

--- a/docker/test-config/logsearch/logsearch-sso.properties
+++ b/docker/test-config/logsearch/logsearch-sso.properties
@@ -16,20 +16,16 @@
 logsearch.solr.zk_connect_string=localhost:9983
 
 # Service Logs
-logsearch.solr.collection.service.logs=hadoop_logs
-
-logsearch.service.logs.split.interval.mins=15
-logsearch.collection.service.logs.numshards=3
-logsearch.collection.service.logs.replication.factor=2
+logsearch.solr.service.logs.collection=hadoop_logs
+logsearch.solr.service.logs.numshards=3
+logsearch.solr.service.logs.replication.factor=2
 
 # Audit logs
 logsearch.solr.audit.logs.zk_connect_string=localhost:9983
 logsearch.solr.collection.audit.logs=audit_logs
 logsearch.solr.audit.logs.url=
-
-logsearch.audit.logs.split.interval.mins=15
-logsearch.collection.audit.logs.numshards=3
-logsearch.collection.audit.logs.replication.factor=2
+logsearch.solr.audit.logs.numshards=3
+logsearch.solr.audit.logs.replication.factor=2
 
 logsearch.solr.config_set.folder=/root/ambari/ambari-logsearch/ambari-logsearch-server/target/package/conf/solr_configsets
 logsearch.solr.audit.logs.config_set.folder=/root/ambari/ambari-logsearch/ambari-logsearch-server/target/package/conf/solr_configsets

--- a/docker/test-config/logsearch/logsearch-sso.properties
+++ b/docker/test-config/logsearch/logsearch-sso.properties
@@ -22,7 +22,7 @@ logsearch.solr.service.logs.replication.factor=2
 
 # Audit logs
 logsearch.solr.audit.logs.zk_connect_string=localhost:9983
-logsearch.solr.collection.audit.logs=audit_logs
+logsearch.solr.audit.logs.collection=audit_logs
 logsearch.solr.audit.logs.url=
 logsearch.solr.audit.logs.numshards=3
 logsearch.solr.audit.logs.replication.factor=2

--- a/docker/test-config/logsearch/logsearch.properties
+++ b/docker/test-config/logsearch/logsearch.properties
@@ -16,30 +16,30 @@
 logsearch.solr.zk_connect_string=localhost:9983
 
 # Service Logs
-logsearch.solr.collection.service.logs=hadoop_logs
+logsearch.solr.service.logs.collection=hadoop_logs
 
 #logsearch.config.api.filter.solr.enabled=true
 #logsearch.config.api.enabled=false
 #logsearch.config.api.filter.zk.enabled=true
 
-logsearch.collection.service.logs.numshards=3
-logsearch.collection.service.logs.replication.factor=2
+logsearch.solr.service.logs.numshards=3
+logsearch.solr.service.logs.replication.factor=2
 
 # Audit logs
+logsearch.solr.audit.logs.collection=audit_logs
 logsearch.solr.audit.logs.zk_connect_string=localhost:9983
-logsearch.solr.collection.audit.logs=audit_logs
 logsearch.solr.audit.logs.url=
 
-logsearch.collection.audit.logs.numshards=3
-logsearch.collection.audit.logs.replication.factor=2
+logsearch.solr.audit.logs.numshards=3
+logsearch.solr.audit.logs.replication.factor=2
 
 logsearch.solr.config_set.folder=/root/ambari/ambari-logsearch/ambari-logsearch-server/target/package/conf/solr_configsets
 logsearch.solr.audit.logs.config_set.folder=/root/ambari/ambari-logsearch/ambari-logsearch-server/target/package/conf/solr_configsets
 
 # History logs
-logsearch.solr.collection.metadata=logsearch_metadata
+logsearch.solr.metadata.collection=logsearch_metadata
 logsearch.solr.metadata.config.name=logsearch_metadata
-logsearch.collection.metadata.replication.factor=1
+logsearch.solr.metadata.replication.factor=1
 
 # Metrics
 logsearch.solr.metrics.collector.hosts=

--- a/jenkins/containers/docker-logsearch-portal/conf/logsearch.properties
+++ b/jenkins/containers/docker-logsearch-portal/conf/logsearch.properties
@@ -20,28 +20,26 @@ logsearch.config.api.enabled=false
 logsearch.config.api.filter.zk.enabled=true
 
 # Service Logs
-logsearch.solr.collection.service.logs=service_logs
+logsearch.solr.service.logs.collection=service_logs
 logsearch.solr.service.logs.config.name=hadoop_logs
 
-logsearch.collection.service.logs.numshards=2
-logsearch.collection.service.logs.replication.factor=2
+logsearch.solr.service.logs.numshards=2
+logsearch.solr.service.logs.replication.factor=2
 
 # Audit logs
 logsearch.solr.audit.logs.zk_connect_string=localhost:9983
-logsearch.solr.collection.audit.logs=audit_logs
+logsearch.solr.audit.logs.collection=audit_logs
 logsearch.solr.audit.logs.url=
-
-logsearch.audit.logs.split.interval.mins=15
-logsearch.collection.audit.logs.numshards=2
-logsearch.collection.audit.logs.replication.factor=2
+logsearch.solr.audit.logs.numshards=2
+logsearch.solr.audit.logs.replication.factor=2
 
 logsearch.solr.config_set.folder=/usr/lib/ambari-logsearch-portal/conf/solr_configsets
 logsearch.solr.audit.logs.config_set.folder=/usr/lib/ambari-logsearch-portal/conf/solr_configsets
 
 # Log search metadata
-logsearch.solr.collection.metadata=logsearch_metadata
+logsearch.solr.metadata.collection=logsearch_metadata
 logsearch.solr.metadata.config.name=logsearch_metadata
-logsearch.collection.metadata.replication.factor=1
+logsearch.solr.metadata.replication.factor=1
 
 # Metrics
 logsearch.solr.metrics.collector.hosts=


### PR DESCRIPTION
# What changes were proposed in this pull request?
Cleanup logsearch property names - use similar prefixes, do not mix it up
## How was this patch tested?
with docker env
