### PR TITLE
AMBARI-24959. Log Search: show log level filters are enabled or disabled on /info/features endpoint

### DIFF
--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/LogSearchConstants.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/common/LogSearchConstants.java
@@ -62,6 +62,7 @@ public class LogSearchConstants {
   public static final String SORT = "sort";
 
   // info features constants
+  public static final String LOG_LEVEL_FILTERS_KEY = "log_level_filters";
   public static final String SHIPPER_CONFIG_API_KEY = "metadata_patterns";
   public static final String AUTH_FEATURE_KEY = "auth";
 

--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/InfoManager.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/manager/InfoManager.java
@@ -81,6 +81,8 @@ public class InfoManager extends JsonManagerBase {
     Map<String, Object> featuresMap = new HashMap<>();
     featuresMap.put(LogSearchConstants.AUTH_FEATURE_KEY, getAuthMap());
     featuresMap.put(LogSearchConstants.SHIPPER_CONFIG_API_KEY, logSearchConfigApiConfig.isConfigApiEnabled());
+    boolean logLevelFiltersEnabled = logSearchConfigApiConfig.isConfigApiEnabled() || logSearchConfigApiConfig.isSolrFilterStorage() || logSearchConfigApiConfig.isZkFilterStorage();
+    featuresMap.put(LogSearchConstants.LOG_LEVEL_FILTERS_KEY, logLevelFiltersEnabled);
     return featuresMap;
   }
 


### PR DESCRIPTION
# What changes were proposed in this pull request?
show log level filters are enabled or disabled on /info/features endpoint.
Later, it can be used by the UI to disable the log level filter setting, if it cannot be used by BE

## How was this patch tested?
with docker env manually
