### PR TITLE
AMBARI-24662. Support non-plain text passwords for LDAP authentication

### DIFF
--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchLdapAuthConfig.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/LogSearchLdapAuthConfig.java
@@ -58,6 +58,16 @@ public class LogSearchLdapAuthConfig {
   )
   private String ldapManagerPassword;
 
+  @Value("${logsearch.auth.ldap.manager.password.file:}")
+  @LogSearchPropertyDescription(
+    name = "logsearch.auth.ldap.manager.password.file",
+    description = "File that contains password of the LDAP manager user.",
+    examples = {"/my/path/passwordfile"},
+    defaultValue = "",
+    sources = {LOGSEARCH_PROPERTIES_FILE}
+  )
+  private String ldapManagerPasswordFile;
+
   @Value("${logsearch.auth.ldap.base.dn:}")
   @LogSearchPropertyDescription(
     name = "logsearch.auth.ldap.base.dn",
@@ -278,5 +288,13 @@ public class LogSearchLdapAuthConfig {
 
   public void setReferralMethod(String referralMethod) {
     this.referralMethod = referralMethod;
+  }
+
+  public String getLdapManagerPasswordFile() {
+    return ldapManagerPasswordFile;
+  }
+
+  public void setLdapManagerPasswordFile(String ldapManagerPasswordFile) {
+    this.ldapManagerPasswordFile = ldapManagerPasswordFile;
   }
 }


### PR DESCRIPTION
# What changes were proposed in this pull request?
- use different ways to get LDAP password for Log Search
 right now we are only getting password with these methods for ldap, long term solution will be to create an ambari-logsearch-common module, which will contain secret store methods, those will be used by logfeeder and logsearch as well

## How was this patch tested?
not needed, not used feature yet.