### PR TITLE
AMBARI-24833. ABFS (ADLS v2) fs implementation was not included on the classpath

### DIFF
--- a/ambari-logsearch-logfeeder/pom.xml
+++ b/ambari-logsearch-logfeeder/pom.xml
@@ -175,12 +175,12 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-azure</artifactId>
-      <version>${hadoop.version}</version>
+      <version>${hdp-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-azure-datalake</artifactId>
-      <version>${hadoop.version}</version>
+      <version>${hdp-hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.bigdataoss</groupId>

--- a/ambari-logsearch-logfeeder/pom.xml
+++ b/ambari-logsearch-logfeeder/pom.xml
@@ -175,12 +175,12 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-azure</artifactId>
-      <version>${hdp-hadoop.version}</version>
+      <version>${hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-azure-datalake</artifactId>
-      <version>${hdp-hadoop.version}</version>
+      <version>${hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.bigdataoss</groupId>

--- a/ambari-logsearch-logfeeder/src/main/resources/core-site-examples/abfs-core-site.xml
+++ b/ambari-logsearch-logfeeder/src/main/resources/core-site-examples/abfs-core-site.xml
@@ -1,0 +1,54 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>abfs://logsearch@myaccount.dfs.core.windows.net</value>
+  </property>
+  <property>
+    <name>fs.azure.account.key.myaccount.dfs.core.windows.net</name>
+    <value>mySecretAccessKey</value>
+  </property>
+  <property>
+    <name>fs.adlsGen2.impl</name>
+    <value>org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem</value>
+  </property>
+  <property>
+    <name>fs.abfss.impl</name>
+    <value>org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem</value>
+  </property>
+  <property>
+    <name>fs.AbstractFileSystem.adlsGen2.impl</name>
+    <value>org.apache.hadoop.fs.azurebfs.Abfs</value>
+  </property>
+  <property>
+    <name>fs.AbstractFileSystem.abfss.impl</name>
+    <value>org.apache.hadoop.fs.azurebfs.Abfss</value>
+  </property>
+  <property>
+    <name>fs.azure.check.block.md5</name>
+    <value>false</value>
+  </property>
+  <property>
+    <name>fs.azure.store.blob.md5</name>
+    <value>false</value>
+  </property>
+  <property>
+    <name>fs.azure.createRemoteFileSystemDuringInitialization</name>
+    <value>true</value>
+  </property>
+</configuration>

--- a/ambari-logsearch-logfeeder/src/main/resources/core-site-examples/s3-core-site.xml
+++ b/ambari-logsearch-logfeeder/src/main/resources/core-site-examples/s3-core-site.xml
@@ -1,0 +1,30 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>s3a://logsearch</value>
+  </property>
+  <property>
+    <name>fs.s3a.access.key</name>
+    <value>MyAccessKey</value>
+  </property>
+  <property>
+    <name>fs.s3a.secret.key</name>
+    <value>MySecretKey</value>
+  </property>
+</configuration>

--- a/ambari-logsearch-logfeeder/src/main/resources/core-site-examples/wasb-core-site.xml
+++ b/ambari-logsearch-logfeeder/src/main/resources/core-site-examples/wasb-core-site.xml
@@ -1,0 +1,42 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>wasb://logsearch@myaccount.blob.core.windows.net</value>
+  </property>
+  <property>
+    <name>fs.azure.account.key.myaccount.blob.core.windows.net</name>
+    <value>mySecretAccessKey</value>
+  </property>
+  <property>
+    <name>fs.AbstractFileSystem.wasb.impl</name>
+    <value>org.apache.hadoop.fs.azure.Wasbs</value>
+  </property>
+  <property>
+    <name>fs.AbstractFileSystem.wasbs.impl</name>
+    <value>org.apache.hadoop.fs.azure.Wasbs</value>
+  </property>
+  <property>
+    <name>fs.azure.selfthrottling.read.factor</name>
+    <value>1.0</value>
+  </property>
+  <property>
+    <name>fs.azure.selfthrottling.write.factor</name>
+    <value>1.0</value>
+  </property>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,7 @@
     <deb.architecture>amd64</deb.architecture>
     <deb.dependency.list>${deb.python.ver}</deb.dependency.list>
     <solr.version>7.5.0</solr.version>
-    <hadoop.version>3.1.1</hadoop.version>
-    <hdp-hadoop.version>3.1.1.3.0.2.0-50</hdp-hadoop.version>
+    <hadoop.version>3.1.1.3.0.2.0-50</hadoop.version>
     <common.io.version>2.5</common.io.version>
     <zookeeper.version>3.4.6.2.3.0.0-2557</zookeeper.version>
     <forkCount>4</forkCount>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <deb.dependency.list>${deb.python.ver}</deb.dependency.list>
     <solr.version>7.5.0</solr.version>
     <hadoop.version>3.1.1</hadoop.version>
+    <hdp-hadoop.version>3.1.1.3.0.2.0-50</hdp-hadoop.version>
     <common.io.version>2.5</common.io.version>
     <zookeeper.version>3.4.6.2.3.0.0-2557</zookeeper.version>
     <forkCount>4</forkCount>


### PR DESCRIPTION
# What changes were proposed in this pull request?
Use specific release of hadoop libraries as ABFS is not included in hadoop 3.1.1 version yet
also add some example core-site.xml s

i## How was this patch tested?
manually with created WASB and ABFS(S) storage accounts on Azure
