### PR TITLE
[AMBARI-24975] Log Search UI: if there are multiple clusters - selecting one of it does not do anything

### DIFF
--- a/ambari-logsearch-web/src/app/modules/shared/components/dropdown-list/dropdown-list.component.html
+++ b/ambari-logsearch-web/src/app/modules/shared/components/dropdown-list/dropdown-list.component.html
@@ -19,7 +19,7 @@
       [attr.role]="item.isDivider ? 'separator' : null" [ngClass]="(item.cssClass || '')" (click)="onItemClick($event)">
     <ng-container *ngIf="!item.isDivider">
       <span class="list-item-label" *ngIf="isMultipleChoice">
-        <input type="checkbox" [attr.id]="(instanceId) + '-' + (item.id || item.value)" [(ngModel)]="item.isChecked"
+        <input type="checkbox" [attr.id]="(instanceId) + '-' + (item.id || item.value)" [ngModel]="item.isChecked"
                (change)="changeSelectedItem({value: item.value, isChecked: $event.currentTarget.checked}, $event)">
         <label [attr.for]="(instanceId) + '-' + (item.id || item.value)" class="label-container">
           <span *ngIf="item.iconClass" [ngClass]="item.iconClass"></span>

--- a/ambari-logsearch-web/src/app/modules/shared/components/dropdown-list/dropdown-list.component.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/components/dropdown-list/dropdown-list.component.ts
@@ -175,20 +175,17 @@ export class DropdownListComponent implements OnInit, OnChanges, AfterViewChecke
   }
 
   selectAll() {
-    this.items.forEach((item: ListItem) => {
-      item.isChecked = true;
-      if (item.onSelect) {
-        item.onSelect(...this.actionArguments);
-      }
-    });
-    this.selectedItemChange.emit(this.items);
+    this.changeSelectedItem(this.items.map((item: ListItem) => ({
+      ...item,
+      isChecked: true
+    })));
   }
 
   unSelectAll() {
-    this.items.forEach((item: ListItem) => {
-      item.isChecked = false;
-    });
-    this.selectedItemChange.emit(this.items);
+    this.changeSelectedItem(this.items.map((item: ListItem) => ({
+      ...item,
+      isChecked: false
+    })));
   }
 
   private onFilterInputKeyUp(event) {
@@ -223,10 +220,12 @@ export class DropdownListComponent implements OnInit, OnChanges, AfterViewChecke
     }
   }
 
-  changeSelectedItem(item: ListItem, event?: MouseEvent): void {
-    if (item.onSelect) {
-      item.onSelect(...this.actionArguments);
-    }
+  changeSelectedItem(item: ListItem | ListItem[], event?: MouseEvent): void {
+    (Array.isArray(item) ? item : [item]).forEach((currentItem: ListItem) => {
+      if (currentItem.onSelect) {
+        currentItem.onSelect(...this.actionArguments)
+      }
+    });
     this.selectedItemChange.emit(item);
   }
 


### PR DESCRIPTION
# What changes were proposed in this pull request?

I removed the bi-direction data binding in dropdown list item, so that the change can be detected in the parent component. Also I changed the way of the selection change in `selectAll` and the `unSelectAll` methods in order to the parent component has chance to detect change(s). 

## How was this patch tested?

It was tested manually (checking all the displayed dropdowns selection change) and by unit tests:
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 292 of 292 SUCCESS (19.635 secs / 19.439 secs)
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
