### PR TITLE
AMBARI-23456. Add mkdocs support & markdown skeletons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node/
 .hgignore
 .hgtags
 .flattened-pom.xml
+mkdocs-site

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,31 @@ rpm:
 deb:
 	$(MAVEN_BINARY) clean package -Dbuild-deb -DskipTests -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
 
+javadoc:
+	$(MAVEN_BINARY) javadoc:aggregate -DskipTests -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
+
+site-only:
+	mkdir -p target/docs && mkdir -p target/docs/javadoc && cp mkdocs.yml target/ && cp -r docs/* target/docs
+	cp ambari-logsearch-docs/src/main/resources/docs.md target/docs/
+	cp -r ambari-logsearch-docs/target/META-INF/resources/webjars/swagger-ui/*/ target/docs/api-docs/ && rm -rf target/docs/api-docs/*.gz
+	sed -i '' 's#https://petstore.swagger.io/v2/swagger.json#./logsearch-swagger.yaml#g' target/docs/api-docs/index.html
+	sed -i '' 's#Swagger UI#Log Search REST API#g' target/docs/api-docs/index.html
+	cp -r target/site/apidocs/* target/docs/javadoc/
+
+site: prop-docs javadoc site-only
+
+serve-site: site
+	cd target && mkdocs serve
+
+serve-site-only: site-only
+	cd target && mkdocs serve
+
+generate-site-html: site
+	cd target && mkdocs build
+
+generate-site-html-only: site-only
+	cd target && mkdocs build
+
 prop-docs: install
 	$(MAVEN_BINARY) -pl ambari-logsearch-docs exec:java -DskipTests -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
 

--- a/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/ConditionsImpl.java
+++ b/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/ConditionsImpl.java
@@ -35,7 +35,8 @@ public class ConditionsImpl implements Conditions {
   @ShipperConfigElementDescription(
     path = "/filter/[]/conditions/fields",
     type = "json object",
-    description = "The fields in the input element of which's value should be met."
+    description = "The fields in the input element of which's value should be met.",
+    examples = {"\"fields\"{\"type\": [\"hdfs_audit\", \"hdfs_datanode\"]}"}
   )
   @Expose
   private FieldsImpl fields;

--- a/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/FieldsImpl.java
+++ b/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/FieldsImpl.java
@@ -38,7 +38,7 @@ public class FieldsImpl implements Fields {
     path = "/filter/[]/conditions/fields/type",
     type = "list of strings",
     description = "The acceptable values for the type field in the input element.",
-    examples = {"ambari_server", "\"spark_jobhistory_server\", \"spark_thriftserver\", \"livy_server\""}
+    examples = {"\"ambari_server\"", "\"spark_jobhistory_server\", \"spark_thriftserver\", \"livy_server\""}
   )
   @Expose
   private Set<String> type;

--- a/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/FilterGrokDescriptorImpl.java
+++ b/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/FilterGrokDescriptorImpl.java
@@ -74,8 +74,8 @@ public class FilterGrokDescriptorImpl extends FilterDescriptorImpl implements Fi
   @ShipperConfigElementDescription(
     path = "/filter/[]/deep_extract",
     type = "boolean",
-    description = "",
-    examples = {""}
+    description = "Keep the full named regex collection for Grok filters.",
+    examples = {"true"}
   )
   @Expose
   @SerializedName("deep_extract")

--- a/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/InputConfigImpl.java
+++ b/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/InputConfigImpl.java
@@ -49,7 +49,7 @@ public class InputConfigImpl implements InputConfig {
     path = "/filter",
     type = "list of json objects",
     description = "A list of filter descriptions",
-    examples = {"{\"filter\" : [ {\"filter\": \"json\", \"conditions\": {\"fields\": { \"type\": [\"mytype1\", \"mytype2\"]} } } ]}"}
+    examples = {"{\"filter\" : [ {\"filter\": \"json\", \"conditions\": {\"fields\": { \"type\": [\"logsearch_app\", \"logsearch_perf\"]} } } ]}"}
   )
   @Expose
   private List<FilterDescriptorImpl> filter;

--- a/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/InputConfigImpl.java
+++ b/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/InputConfigImpl.java
@@ -39,7 +39,8 @@ public class InputConfigImpl implements InputConfig {
   @ShipperConfigElementDescription(
     path = "/input",
     type = "list of json objects",
-    description = "A list of input descriptions"
+    description = "A list of input descriptions",
+    examples = {"{\"input\" : [ {\"type\": \"myinput_service_type\"}] }"}
   )
   @Expose
   private List<InputDescriptorImpl> input;
@@ -47,7 +48,8 @@ public class InputConfigImpl implements InputConfig {
   @ShipperConfigElementDescription(
     path = "/filter",
     type = "list of json objects",
-    description = "A list of filter descriptions"
+    description = "A list of filter descriptions",
+    examples = {"{\"filter\" : [ {\"filter\": \"json\", \"conditions\": {\"fields\": { \"type\": [\"mytype1\", \"mytype2\"]} } } ]}"}
   )
   @Expose
   private List<FilterDescriptorImpl> filter;

--- a/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/InputS3FileDescriptorImpl.java
+++ b/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/InputS3FileDescriptorImpl.java
@@ -34,7 +34,7 @@ public class InputS3FileDescriptorImpl extends InputFileBaseDescriptorImpl imple
   @ShipperConfigElementDescription(
     path = "/input/[]/s3_access_key",
     type = "string",
-    description = "The access key used for AWS credentials."
+    description = "The access key used for AWS credentials. (Not supported yet through shipper configurations)"
   )
   @Expose
   @SerializedName("s3_access_key")
@@ -43,7 +43,7 @@ public class InputS3FileDescriptorImpl extends InputFileBaseDescriptorImpl imple
   @ShipperConfigElementDescription(
     path = "/input/[]/s3_secret_key",
     type = "string",
-    description = "The secret key used for AWS credentials."
+    description = "The secret key used for AWS credentials. (Not supported yet through shipper configurations)"
   )
   @Expose
   @SerializedName("s3_secret_key")
@@ -52,7 +52,7 @@ public class InputS3FileDescriptorImpl extends InputFileBaseDescriptorImpl imple
   @ShipperConfigElementDescription(
     path = "/input/[]/s3_endpoint",
     type = "string",
-    description = "Endpoint URL for S3."
+    description = "Endpoint URL for S3. (Not supported yet through shipper configurations)"
   )
   @Expose
   @SerializedName("s3_endpoint")

--- a/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/InputS3FileDescriptorImpl.java
+++ b/ambari-logsearch-config-json/src/main/java/org/apache/ambari/logsearch/config/json/model/inputconfig/impl/InputS3FileDescriptorImpl.java
@@ -19,7 +19,6 @@
 
 package org.apache.ambari.logsearch.config.json.model.inputconfig.impl;
 
-import org.apache.ambari.logsearch.config.api.ShipperConfigElementDescription;
 import org.apache.ambari.logsearch.config.api.ShipperConfigTypeDescription;
 import org.apache.ambari.logsearch.config.api.model.inputconfig.InputS3FileDescriptor;
 
@@ -31,29 +30,14 @@ import com.google.gson.annotations.SerializedName;
   description = "S3 file inputs have the following parameters in addition to the general file parameters:"
 )
 public class InputS3FileDescriptorImpl extends InputFileBaseDescriptorImpl implements InputS3FileDescriptor {
-  @ShipperConfigElementDescription(
-    path = "/input/[]/s3_access_key",
-    type = "string",
-    description = "The access key used for AWS credentials. (Not supported yet through shipper configurations)"
-  )
   @Expose
   @SerializedName("s3_access_key")
   private String s3AccessKey;
 
-  @ShipperConfigElementDescription(
-    path = "/input/[]/s3_secret_key",
-    type = "string",
-    description = "The secret key used for AWS credentials. (Not supported yet through shipper configurations)"
-  )
   @Expose
   @SerializedName("s3_secret_key")
   private String s3SecretKey;
 
-  @ShipperConfigElementDescription(
-    path = "/input/[]/s3_endpoint",
-    type = "string",
-    description = "Endpoint URL for S3. (Not supported yet through shipper configurations)"
-  )
   @Expose
   @SerializedName("s3_endpoint")
   private String s3Endpoint;

--- a/ambari-logsearch-docs/pom.xml
+++ b/ambari-logsearch-docs/pom.xml
@@ -24,10 +24,10 @@
     <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
+  <artifactId>ambari-logsearch-docs</artifactId>
   <packaging>jar</packaging>
   <url>http://maven.apache.org</url>
   <name>Ambari Logsearch Docs</name>
-  <artifactId>ambari-logsearch-docs</artifactId>
   <build>
     <resources>
       <resource>
@@ -45,6 +45,31 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.8</version>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.webjars</groupId>
+                  <artifactId>swagger-ui</artifactId>
+                  <version>${swagger-ui.version}</version>
+                  <outputDirectory>${project.build.directory}/</outputDirectory>
+                  <includes>META-INF/resources/**</includes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.2.1</version>
@@ -56,7 +81,7 @@
           </execution>
         </executions>
         <configuration>
-          <mainClass>org.apache.ambari.logsearch.doc.LogSearchMarkdownGenerator</mainClass>
+          <mainClass>org.apache.ambari.logsearch.doc.LogSearchDocumentationGenerator</mainClass>
           <arguments>
             <argument>--output-dir</argument>
             <argument>${project.basedir}/../docs</argument>
@@ -82,6 +107,5 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
-
 
 </project>

--- a/ambari-logsearch-docs/src/main/java/org/apache/ambari/logsearch/doc/LogSearchDocumentationGenerator.java
+++ b/ambari-logsearch-docs/src/main/java/org/apache/ambari/logsearch/doc/LogSearchDocumentationGenerator.java
@@ -156,14 +156,7 @@ public class LogSearchDocumentationGenerator {
     swagger.addSecurityDefinition("basicAuth", new BasicAuthDefinition());
     beanConfig.configure(swagger);
     beanConfig.scanAndRead();
-    String yaml = Yaml.mapper().writeValueAsString(swagger);
-    StringBuilder b = new StringBuilder();
-    String[] parts = yaml.split("\n");
-    for (String part : parts) {
-      b.append(part);
-      b.append("\n");
-    }
-    return b.toString();
+    return Yaml.mapper().writeValueAsString(swagger);
   }
 
   private static void writeMarkdown(Configuration freemarkerConfiguration, String templateName,

--- a/ambari-logsearch-docs/src/main/java/org/apache/ambari/logsearch/doc/LogSearchDocumentationGenerator.java
+++ b/ambari-logsearch-docs/src/main/java/org/apache/ambari/logsearch/doc/LogSearchDocumentationGenerator.java
@@ -20,6 +20,11 @@ package org.apache.ambari.logsearch.doc;
 
 import freemarker.template.Configuration;
 import freemarker.template.Template;
+import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.models.Swagger;
+import io.swagger.models.auth.BasicAuthDefinition;
+import io.swagger.util.Yaml;
+import org.apache.ambari.logsearch.conf.ApiDocConfig;
 import org.apache.ambari.logsearch.config.api.LogSearchPropertyDescription;
 import org.apache.ambari.logsearch.config.api.ShipperConfigElementDescription;
 import org.apache.commons.cli.CommandLine;
@@ -42,7 +47,6 @@ import java.nio.charset.Charset;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -51,7 +55,10 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-public class LogSearchMarkdownGenerator {
+/**
+ * Class to generate markdown files based on property annotations + rest API docs with swagger
+ */
+public class LogSearchDocumentationGenerator {
 
   private static final String SHIPPER_CONFIG_TEMPLATE_KEY = "shipperConfigs";
   private static final String LOGSEARCH_PROPERTIES_TEMPLATE_KEY = "logsearchProperties";
@@ -76,6 +83,8 @@ public class LogSearchMarkdownGenerator {
   private static final String SHIPPER_CONFIGURATIONS_MARKDOWN_TEMPLATE_FILE = "shipper_configurations.md.ftl";
   private static final String SHIPPER_CONFIGURATIONS_MARKDOWN_OUTPUT = "shipper_configurations.md";
 
+  private static final String SWAGGER_API_DOC_FOLDER = "api-docs";
+  private static final String SWAGGER_YAML_FILE_NAME = "logsearch-swagger.yaml";
 
   public static void main(String[] args) {
     try {
@@ -102,13 +111,14 @@ public class LogSearchMarkdownGenerator {
       System.out.println(String.format("Number of logsearch.properties configuration descriptors found: %d", propertyDescriptions.get(LOGSEARCH_PROPERTIES).size()));
       System.out.println(String.format("Number of logfeeder.properties configuration descriptors found: %d", propertyDescriptions.get(LOGFEEDER_PROPERTIES).size()));
 
-      final List<String> shipperConfigPackagesToScan = Collections.singletonList(CONFIG_API_PACKAGE);
+      final List<String> shipperConfigPackagesToScan = Arrays.asList(CONFIG_API_PACKAGE, LOGFEEDER_PACKAGE);
       ShipperConfigDescriptionDataHolder shipperConfigDescriptionDataHolder = createShipperConfigDescriptions(shipperConfigPackagesToScan);
 
       System.out.println(String.format("Number of top level section shipper descriptors found: %d", shipperConfigDescriptionDataHolder.getTopLevelConfigSections().size()));
       System.out.println(String.format("Number of input config section shipper descriptors found: %d", shipperConfigDescriptionDataHolder.getInputConfigSections().size()));
       System.out.println(String.format("Number of filter config section shipper descriptors found: %d", shipperConfigDescriptionDataHolder.getFilterConfigSections().size()));
       System.out.println(String.format("Number of mapper section shipper descriptors found: %d", shipperConfigDescriptionDataHolder.getPostMapValuesConfigSections().size()));
+      System.out.println(String.format("Number of output config section shipper descriptors found: %d", shipperConfigDescriptionDataHolder.getOutputConfigSections().size()));
 
       final Configuration freemarkerConfiguration = new Configuration();
       final ClassPathResource cpr = new ClassPathResource(TEMPLATES_FOLDER);
@@ -130,10 +140,30 @@ public class LogSearchMarkdownGenerator {
       File shipperConfigsOutputFile = Paths.get(outputDir, SHIPPER_CONFIGURATIONS_MARKDOWN_OUTPUT).toFile();
       writeMarkdown(freemarkerConfiguration, SHIPPER_CONFIGURATIONS_MARKDOWN_TEMPLATE_FILE, shipperConfigModels, shipperConfigsOutputFile);
 
+      String swaggerYaml = generateSwaggerYaml();
+      File swaggerYamlFile = Paths.get(outputDir, SWAGGER_API_DOC_FOLDER, SWAGGER_YAML_FILE_NAME).toFile();
+      FileUtils.writeStringToFile(swaggerYamlFile, swaggerYaml, Charset.defaultCharset());
     } catch (Exception e) {
       e.printStackTrace();
       System.exit(1);
     }
+  }
+
+  private static String generateSwaggerYaml() throws Exception {
+    ApiDocConfig apiDocConfig = new ApiDocConfig();
+    BeanConfig beanConfig = apiDocConfig.swaggerConfig();
+    Swagger swagger = beanConfig.getSwagger();
+    swagger.addSecurityDefinition("basicAuth", new BasicAuthDefinition());
+    beanConfig.configure(swagger);
+    beanConfig.scanAndRead();
+    String yaml = Yaml.mapper().writeValueAsString(swagger);
+    StringBuilder b = new StringBuilder();
+    String[] parts = yaml.split("\n");
+    for (String part : parts) {
+      b.append(part);
+      b.append("\n");
+    }
+    return b.toString();
   }
 
   private static void writeMarkdown(Configuration freemarkerConfiguration, String templateName,
@@ -187,7 +217,14 @@ public class LogSearchMarkdownGenerator {
       .distinct()
       .collect(Collectors.toList());
 
-    return new ShipperConfigDescriptionDataHolder(topLevelConfigSections, inputConfigSection, filterConfigSection, postMapValuesConfigSection);
+    final List<ShipperConfigDescriptionData> outputConfigSection = shipperConfigDescription.stream()
+      .filter(
+        s -> s.getPath().startsWith("/output/[]"))
+      .distinct()
+      .collect(Collectors.toList());
+
+    return new ShipperConfigDescriptionDataHolder(topLevelConfigSections, inputConfigSection, filterConfigSection,
+      postMapValuesConfigSection, outputConfigSection);
   }
 
   private static List<PropertyDescriptionData> getPropertyDescriptions(List<String> packagesToScan) {

--- a/ambari-logsearch-docs/src/main/java/org/apache/ambari/logsearch/doc/ShipperConfigDescriptionDataHolder.java
+++ b/ambari-logsearch-docs/src/main/java/org/apache/ambari/logsearch/doc/ShipperConfigDescriptionDataHolder.java
@@ -25,15 +25,18 @@ public class ShipperConfigDescriptionDataHolder {
   private final List<ShipperConfigDescriptionData> inputConfigSections;
   private final List<ShipperConfigDescriptionData> filterConfigSections;
   private final List<ShipperConfigDescriptionData> postMapValuesConfigSections;
+  private final List<ShipperConfigDescriptionData> outputConfigSections;
 
   public ShipperConfigDescriptionDataHolder(List<ShipperConfigDescriptionData> topLevelConfigSections,
                                             List<ShipperConfigDescriptionData> inputConfigSections,
                                             List<ShipperConfigDescriptionData> filterConfigSections,
-                                            List<ShipperConfigDescriptionData> postMapValuesConfigSections) {
+                                            List<ShipperConfigDescriptionData> postMapValuesConfigSections,
+                                            List<ShipperConfigDescriptionData> outputConfigSections) {
     this.topLevelConfigSections = topLevelConfigSections;
     this.inputConfigSections = inputConfigSections;
     this.filterConfigSections = filterConfigSections;
     this.postMapValuesConfigSections = postMapValuesConfigSections;
+    this.outputConfigSections = outputConfigSections;
   }
 
   public List<ShipperConfigDescriptionData> getTopLevelConfigSections() {
@@ -50,5 +53,9 @@ public class ShipperConfigDescriptionDataHolder {
 
   public List<ShipperConfigDescriptionData> getPostMapValuesConfigSections() {
     return postMapValuesConfigSections;
+  }
+
+  public List<ShipperConfigDescriptionData> getOutputConfigSections() {
+    return outputConfigSections;
   }
 }

--- a/ambari-logsearch-docs/src/main/resources/docs.md
+++ b/ambari-logsearch-docs/src/main/resources/docs.md
@@ -1,0 +1,24 @@
+<!---
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+## REST API documentation
+
+[Swagger Doc UI](/api-docs)
+
+## Javadoc
+
+[Java doc link](/javadoc)

--- a/ambari-logsearch-docs/src/main/resources/templates/shipper_configurations.md.ftl
+++ b/ambari-logsearch-docs/src/main/resources/templates/shipper_configurations.md.ftl
@@ -69,7 +69,7 @@ Example:
     {
       "type": "simple_service",
       "rowtype": "service",
-      "path": "/var/logs/my/service/service_sample.txt",
+      "path": "/var/logs/my/service/service_sample.log",
       "group": "Ambari",
       "cache_enabled": "true",
       "cache_key_field": "log_message",
@@ -87,7 +87,7 @@ Example:
     {
       "type": "simple_audit_service",
       "rowtype": "audit",
-      "path": "/var/logs/my/service/service_audit_sample.txt",
+      "path": "/var/logs/my/service/service_audit_sample.log",
       "is_enabled": "true",
       "add_fields": {
         "logType": "AmbariAudit",
@@ -100,7 +100,7 @@ Example:
     {
      "type": "wildcard_log_service",
      "rowtype": "service",
-     "path": "/var/logs/my/service/*/service_audit_sample.txt",
+     "path": "/var/logs/my/service/*/service_audit_sample.log",
      "init_default_fields" : "true",
      "detach_interval_min": "50",
      "detach_time_min" : "300",

--- a/ambari-logsearch-docs/src/main/resources/templates/shipper_configurations.md.ftl
+++ b/ambari-logsearch-docs/src/main/resources/templates/shipper_configurations.md.ftl
@@ -127,7 +127,6 @@ Example:
   ]
 }
 ```
-Built-in input shipper configurations:
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
 <#if shipperConfigs.inputConfigSections??>
@@ -139,6 +138,25 @@ Built-in input shipper configurations:
 ### Filter Descriptor
 
 Filter configurations can be defined in the filter descriptor section.
+- Sample 1 for example (json - simple_service_json):
+```json
+{"level":"WARN","file":"ClientCnxn.java","thread_name":"zkCallback-6-thread-10-SendThread(c6402.ambari.apache.org:2181)","line_number":1102,"log_message":"Session 0x355e0023b38001d for server null, unexpected error, closing socket connection and attempting reconnect\njava.net.SocketException: Network is unreachable\n\tat sun.nio.ch.Net.connect0(Native Method)\n\tat sun.nio.ch.Net.connect(Net.java:454)\n\tat sun.nio.ch.Net.connect(Net.java:446)\n\tat sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:648)\n\tat org.apache.zookeeper.ClientCnxnSocketNIO.registerAndConnect(ClientCnxnSocketNIO.java:277)\n\tat org.apache.zookeeper.ClientCnxnSocketNIO.connect(ClientCnxnSocketNIO.java:287)\n\tat org.apache.zookeeper.ClientCnxn$SendThread.startConnect(ClientCnxn.java:967)\n\tat org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1003)\n","logger_name":"org.apache.zookeeper.ClientCnxn","logtime":"1468406756757"}
+```
+- Sample 2 for example (grok - simple_service):
+```text
+2016-07-13 10:45:49,640 [WARN] Sample log line 1 - warn level
+that is a multiline
+2016-07-13 10:45:49,640 [ERROR] Sample log line 2 - error level
+2016-07-13 10:45:50,351 [INFO] Sample log line 3 - info level
+```
+- Sample 3 for example (grok + key/value - ambari_audit):
+```text
+2016-10-03T16:26:13.333Z, User(admin), RemoteIp(192.168.64.1), Operation(User login), Roles(
+    Ambari: Ambari Administrator
+), Status(Success)
+2016-10-03T16:26:54.834Z, User(admin), RemoteIp(192.168.64.1), Operation(Repository update), RequestType(PUT), url(http://c6401.ambari.apache.org:8080/api/v1/stacks/HDP/versions/2.5/operating_systems/redhat6/repositories/HDP-UTILS-1.1.0.21), ResultStatus(200 OK), Stack(HDP), Stack version(2.5), OS(redhat6), Repo id(HDP-UTILS-1.1.0.21), Base URL(http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos6)
+2016-10-03T16:26:54.845Z, User(admin), RemoteIp(192.168.64.1), Operation(Repository update), RequestType(PUT), url(http://c6401.ambari.apache.org:8080/api/v1/stacks/HDP/versions/2.5/operating_systems/redhat7/repositories/HDP-2.5), ResultStatus(200 OK), Stack(HDP), Stack version(2.5), OS(redhat7), Repo id(HDP-2.5), Base URL(http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.5.0.0/)
+```
 Example:
 ```json
 {
@@ -154,7 +172,7 @@ Example:
           ]
         }
       }
-    }
+    },
     {
       "filter": "grok",
       "deep_extract": "false",
@@ -167,9 +185,9 @@ Example:
           ]
         }
       },
-      "log4j_format":"%d{ISO8601} %5p [%t] %c{1}:%L - %m%n",
+      "log4j_format":"# can be anything - only use it as marker/helper as it does not supported yet",
       "multiline_pattern":"^(%{TIMESTAMP_ISO8601:logtime})",
-      "message_pattern":"(?m)^%{TIMESTAMP_ISO8601:logtime}%{SPACE}%{LOGLEVEL:level}%{SPACE}\\[%{DATA:thread_name}\\]%{SPACE}%{JAVACLASS:logger_name}:%{INT:line_number}%{SPACE}-%{SPACE}%{GREEDYDATA:log_message}",
+      "message_pattern":"(?m)^%{TIMESTAMP_ISO8601:logtime}%{SPACE}\\[%{LOGLEVEL:level}\\]%{SPACE}%{GREEDYDATA:log_message}}",
       "post_map_values":{
         "logtime":{
           "map_date":{
@@ -226,7 +244,6 @@ Example:
   ]
 }
 ```
-Built-in filter shipper configurations:
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
 <#if shipperConfigs.filterConfigSections??>
@@ -286,7 +303,6 @@ Example:
   ]
 }
 ```
-Built-in mapper shipper configurations:
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
 <#if shipperConfigs.postMapValuesConfigSections??>
@@ -336,7 +352,6 @@ Example:
   ]
 }
 ```
-Built-in output shipper configurations:
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
 |`/output/[]/conditions`|The conditions of which input to filter.|`EMPTY`||

--- a/ambari-logsearch-docs/src/main/resources/templates/shipper_configurations.md.ftl
+++ b/ambari-logsearch-docs/src/main/resources/templates/shipper_configurations.md.ftl
@@ -17,19 +17,117 @@ limitations under the License.
 
 ## Log Feeder Shipper Descriptor
 
-### Top Level Descriptor Sections
+### Top Level Descriptors
 
+Input, Filter and Output configurations are defined in 3 (at least) different files. (note: there can be multiple input configuration files, but only 1 output and global configuration)
+
+input.config-myservice.json example:
+```json
+{
+  "input" : [
+  ],
+  "filter" : [
+  ]
+}
+```
+output.config.json example:
+```json
+{
+  "output" : [
+  ]
+}
+```
+global.config.json example:
+```json
+{
+  "global" : {
+    "source" : "file",
+    "add_fields":{
+      "cluster":"cl1"
+    },
+    "tail" : "true"
+  }
+}
+```
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
-<#if shipperConfigs.topLevelSections??>
-    <#list shipperConfigs.topLevelSections as section>
+<#if shipperConfigs.topLevelConfigSections??>
+    <#list shipperConfigs.topLevelConfigSections as section>
 |`${section.path}`|${section.description}|${section.defaultValue}|${section.examples}|
     </#list>
 </#if>
-|`/output`|A list of output descriptors|`{}`||
+|`/output`|A list of output descriptors|`{}`|<ul><li>`{"output": [{"is_enabled" : "true", "destination": "solr", "myfield": "myvalue"}]`</li></ul>|
+|`/global`|A map that contains field/value pairs|`EMPTY`|<ul><li>`{"global": {"myfield": "myvalue"}}`</li></ul>|
 
-### Input Descriptor Sections
+### Input Descriptor
 
+Input configurations (for monitoring logs) can be defined in the input descriptor section.
+Example:
+```json
+{
+  "input" : [
+    {
+      "type": "simple_service",
+      "rowtype": "service",
+      "path": "/var/logs/my/service/service_sample.txt",
+      "group": "Ambari",
+      "cache_enabled": "true",
+      "cache_key_field": "log_message",
+      "cache_size": "50"
+    },
+    {
+      "type": "simple_service_json",
+      "rowtype": "service",
+      "path": "/var/logs/my/service/service_sample.json",
+      "properties": {
+        "myKey1" : "myValue1",
+        "myKey2" : "myValue2"
+      }
+    },
+    {
+      "type": "simple_audit_service",
+      "rowtype": "audit",
+      "path": "/var/logs/my/service/service_audit_sample.txt",
+      "is_enabled": "true",
+      "add_fields": {
+        "logType": "AmbariAudit",
+        "enforcer": "ambari-acl",
+        "repoType": "1",
+        "repo": "ambari",
+        "level": "INFO"
+      }
+    },
+    {
+     "type": "wildcard_log_service",
+     "rowtype": "service",
+     "path": "/var/logs/my/service/*/service_audit_sample.txt",
+     "init_default_fields" : "true",
+     "detach_interval_min": "50",
+     "detach_time_min" : "300",
+     "path_update_interval_min" : "10",
+     "max_age_min" : "800"
+    },
+    {
+      "type": "service_socket",
+      "rowtype": "service",
+      "port": 61999,
+      "protocol" : "tcp",
+      "secure" : "false",
+      "source" : "socket",
+      "log4j": "true"
+    },
+    {
+      "type": "docker_service",
+      "rowtype": "service",
+      "docker" : "true",
+      "default_log_levels" : [
+         "FATAL", "ERROR", "WARN", "INFO", "DEBUG"
+      ]
+    }
+  ]
+}
+```
+Built-in input shipper configurations:
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
 <#if shipperConfigs.inputConfigSections??>
@@ -38,8 +136,97 @@ limitations under the License.
     </#list>
 </#if>
 
-### Filter Descriptor Sections
+### Filter Descriptor
 
+Filter configurations can be defined in the filter descriptor section.
+Example:
+```json
+{
+  "input" : [
+  ],
+  "filter": [
+    {
+      "filter": "json",
+      "conditions": {
+        "fields": {
+          "type": [
+            "simple_service_json"
+          ]
+        }
+      }
+    }
+    {
+      "filter": "grok",
+      "deep_extract": "false",
+      "conditions":{
+        "fields":{
+          "type":[
+            "simple_service",
+            "simple_audit_service",
+            "docker_service"
+          ]
+        }
+      },
+      "log4j_format":"%d{ISO8601} %5p [%t] %c{1}:%L - %m%n",
+      "multiline_pattern":"^(%{TIMESTAMP_ISO8601:logtime})",
+      "message_pattern":"(?m)^%{TIMESTAMP_ISO8601:logtime}%{SPACE}%{LOGLEVEL:level}%{SPACE}\\[%{DATA:thread_name}\\]%{SPACE}%{JAVACLASS:logger_name}:%{INT:line_number}%{SPACE}-%{SPACE}%{GREEDYDATA:log_message}",
+      "post_map_values":{
+        "logtime":{
+          "map_date":{
+            "target_date_pattern":"yyyy-MM-dd HH:mm:ss,SSS"
+          }
+        }
+      }
+    },
+    {
+      "filter": "grok",
+      "conditions": {
+        "fields": {
+          "type": [
+            "ambari_audit"
+          ]
+        }
+      },
+      "log4j_format": "%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n",
+      "multiline_pattern": "^(%{TIMESTAMP_ISO8601:evtTime})",
+      "message_pattern": "(?m)^%{TIMESTAMP_ISO8601:evtTime},%{SPACE}%{GREEDYDATA:log_message}",
+      "post_map_values": {
+        "evtTime": {
+          "map_date": {
+            "target_date_pattern": "yyyy-MM-dd'T'HH:mm:ss.SSSXX"
+          }
+        }
+      }
+    },
+    {
+      "filter": "keyvalue",
+      "sort_order": 1,
+      "conditions": {
+        "fields": {
+          "type": [
+            "ambari_audit"
+          ]
+        }
+      },
+      "source_field": "log_message",
+      "field_split": ", ",
+      "value_borders": "()",
+      "post_map_values": {
+        "User": {
+          "map_field_value": {
+            "pre_value": "null",
+            "post_value": "unknown"
+          },
+          "map_field_name": {
+            "new_field_name": "reqUser"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+Built-in filter shipper configurations:
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
 <#if shipperConfigs.filterConfigSections??>
@@ -48,8 +235,58 @@ limitations under the License.
     </#list>
 </#if>
 
-### Mapper Descriptor Sections
+### Mapper Descriptor
 
+Mapper configurations are defined inside filters, it can alter fields.
+Example:
+```json
+{
+  "input": [
+  ],
+  "filter": [
+    {
+      "filter": "keyvalue",
+      "sort_order": 1,
+      "conditions": {
+        "fields": {
+          "type": [
+            "ambari_audit"
+          ]
+        }
+      },
+      "source_field": "log_message",
+      "field_split": ", ",
+      "value_borders": "()",
+      "post_map_values": {
+        "Status": {
+          "map_field_value": {
+            "pre_value": "null",
+            "post_value": "unknown"
+          },
+          "map_field_name": {
+            "new_field_name": "ws_status"
+          }
+        },
+        "StatusWithRepeatedKeys": [
+          {
+            "map_field_value": {
+              "pre_value": "Failed",
+              "post_value": "0"
+            }
+          },
+          {
+            "map_field_value": {
+              "pre_value": "Failed to queue",
+              "post_value": "0"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+Built-in mapper shipper configurations:
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
 <#if shipperConfigs.postMapValuesConfigSections??>
@@ -58,8 +295,56 @@ limitations under the License.
     </#list>
 </#if>
 
-### Output Descriptor Sections
+### Output Descriptor
 
+Output configurations can be defined in the output descriptor section. (it can support any extra - output specific - key value pairs)
+Example:
+
+```json
+{
+  "output": [
+    {
+      "is_enabled": "true",
+      "comment": "Output to solr for service logs",
+      "collection" : "hadoop_logs",
+      "destination": "solr",
+      "zk_connect_string": "localhost:9983",
+      "type": "service",
+      "conditions": {
+        "fields": {
+          "rowtype": [
+            "service"
+          ]
+        }
+      }
+    },
+    {
+      "comment": "Output to solr for audit records",
+      "is_enabled": "true",
+      "collection" : "audit_logs",
+      "destination": "solr",
+      "zk_connect_string": "localhost:9983",
+      "type": "audit",
+      "conditions": {
+        "fields": {
+          "rowtype": [
+            "audit"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+Built-in output shipper configurations:
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
+|`/output/[]/conditions`|The conditions of which input to filter.|`EMPTY`||
+|`/output/[]/conditions/fields`|The fields in the input element of which's value should be met.|`EMPTY`|<ul><li>`"fields"{"type": ["hdfs_audit", "hdfs_datanode"]}`</li></ul>|
+|`/output/[]/conditions/fields/type`|The acceptable values for the type field in the input element.|`EMPTY`|<ul><li>`"ambari_server"`</li><li>`"spark_jobhistory_server", "spark_thriftserver", "livy_server"`</li></ul>|
 |`/output/[]/is_enabled`|A flag to show if the output should be used.|true|<ul><li>`true`</li><li>`false`</li></ul>|
+<#if shipperConfigs.outputConfigSections??>
+  <#list shipperConfigs.outputConfigSections as section>
+|`${section.path}`|${section.description}|${section.defaultValue}|${section.examples}|
+  </#list>
+</#if>

--- a/ambari-logsearch-logfeeder-plugin-api/src/main/java/org/apache/ambari/logfeeder/plugin/output/Output.java
+++ b/ambari-logsearch-logfeeder-plugin-api/src/main/java/org/apache/ambari/logfeeder/plugin/output/Output.java
@@ -26,6 +26,7 @@ import org.apache.ambari.logfeeder.plugin.common.MetricData;
 import org.apache.ambari.logfeeder.plugin.input.InputMarker;
 import org.apache.ambari.logsearch.config.api.LogSearchConfigLogFeeder;
 import org.apache.ambari.logsearch.config.api.OutputConfigMonitor;
+import org.apache.ambari.logsearch.config.api.ShipperConfigElementDescription;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -47,10 +48,16 @@ public abstract class Output<PROP_TYPE extends LogFeederProperties, INPUT_MARKER
   private static Gson gson = new GsonBuilder().setDateFormat(GSON_DATE_FORMAT).create();
 
   private LogSearchConfigLogFeeder logSearchConfig;
+
+  @ShipperConfigElementDescription(
+    path = "/output/[]/destination",
+    type = "string",
+    description = "Alias of a supported output (e.g.: solr). The class-alias mapping should exist in the alias config.",
+    examples = {"\"solr\"", "\"hdfs\""}
+  )
   private String destination = null;
   private boolean isClosed;
   protected MetricData writeBytesMetric = new MetricData(getWriteBytesMetricName(), false);
-
   /**
    * Obtain the output type
    * @return Text which represents the output type in shipper configuration. (e.g.: "solr")

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederProps.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederProps.java
@@ -253,7 +253,7 @@ public class LogFeederProps implements LogFeederProperties {
   @LogSearchPropertyDescription(
     name = LogFeederConstants.CLOUD_STORAGE_DESTINATION,
     description = "Type of storage that is the destination for cloud output logs.",
-    examples = {"hdfs", "s3", "gcs", "adls", "wasb", "none"},
+    examples = {"hdfs", "s3"},
     defaultValue = "none",
     sources = {LogFeederConstants.LOGFEEDER_PROPERTIES_FILE}
   )

--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputSolr.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/output/OutputSolr.java
@@ -26,6 +26,7 @@ import org.apache.ambari.logfeeder.plugin.input.InputMarker;
 import org.apache.ambari.logfeeder.plugin.output.Output;
 import org.apache.ambari.logfeeder.util.DateUtil;
 import org.apache.ambari.logfeeder.util.LogFeederUtil;
+import org.apache.ambari.logsearch.config.api.ShipperConfigElementDescription;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
@@ -88,8 +89,6 @@ public class OutputSolr extends Output<LogFeederProps, InputMarker> {
 
   private static final Logger logger = LogManager.getLogger(OutputSolr.class);
 
-  private static final int SHARDS_WAIT_MS = 10000;
-
   private static final int DEFAULT_MAX_BUFFER_SIZE = 5000;
   private static final int DEFAULT_MAX_INTERVAL_MS = 3000;
   private static final int DEFAULT_NUMBER_OF_WORKERS = 1;
@@ -100,6 +99,12 @@ public class OutputSolr extends Output<LogFeederProps, InputMarker> {
   private static final String JAVA_SECURITY_AUTH_LOGIN_CONFIG = "java.security.auth.login.config";
   private static final String SOLR_HTTPCLIENT_BUILDER_FACTORY = "solr.httpclient.builder.factory";
 
+  @ShipperConfigElementDescription(
+    path = "/output/[]/type",
+    type = "string",
+    description = "Output type name, right now it can be service or audit",
+    examples = {"\"service\"", "\"audit\""}
+  )
   private String type;
   private String collection;
   private int splitInterval;

--- a/ambari-logsearch-server/pom.xml
+++ b/ambari-logsearch-server/pom.xml
@@ -35,7 +35,6 @@
     <jersey.version>2.27</jersey.version>
     <jetty.version>9.4.12.v20180830</jetty.version>
     <swagger.version>1.5.16</swagger.version>
-    <swagger-ui.version>3.19.0</swagger-ui.version>
     <spring.ldap.version>2.3.2.RELEASE</spring.ldap.version>
     <spring-data-solr.version>3.0.10.RELEASE</spring-data-solr.version>
     <spring-data.version>2.0.10.RELEASE</spring-data.version>

--- a/ambari-logsearch-server/pom.xml
+++ b/ambari-logsearch-server/pom.xml
@@ -35,6 +35,7 @@
     <jersey.version>2.27</jersey.version>
     <jetty.version>9.4.12.v20180830</jetty.version>
     <swagger.version>1.5.16</swagger.version>
+    <swagger-ui.version>3.19.0</swagger-ui.version>
     <spring.ldap.version>2.3.2.RELEASE</spring.ldap.version>
     <spring-data-solr.version>3.0.10.RELEASE</spring-data-solr.version>
     <spring-data.version>2.0.10.RELEASE</spring-data.version>
@@ -572,7 +573,7 @@
     <dependency>
       <groupId>org.webjars</groupId>
       <artifactId>swagger-ui</artifactId>
-      <version>3.19.0</version>
+      <version>${swagger-ui.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.data</groupId>

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,16 @@
+<!---
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->

--- a/docs/add_new_input.md
+++ b/docs/add_new_input.md
@@ -1,0 +1,16 @@
+<!---
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->

--- a/docs/api-docs/logsearch-swagger.yaml
+++ b/docs/api-docs/logsearch-swagger.yaml
@@ -19,371 +19,6 @@ schemes:
 - "http"
 - "https"
 paths:
-  /audit/logs/schema/fields:
-    get:
-      tags:
-      - "auditlogs"
-      summary: "Get list of schema fields in audit collection"
-      description: ""
-      operationId: "getSolrFieldListGet"
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AuditFieldMetadataResponse"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "auditlogs"
-      summary: "Get list of schema fields in audit collection"
-      description: ""
-      operationId: "getSolrFieldListPost"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AuditFieldMetadataResponse"
-      security:
-      - basicAuth: []
-  /audit/logs:
-    get:
-      tags:
-      - "auditlogs"
-      summary: "Get the list of logs details"
-      description: ""
-      operationId: "getAuditLogsGet"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "startIndex"
-        in: "query"
-        description: "Start index of the queried result"
-        required: false
-        type: "string"
-      - name: "page"
-        in: "query"
-        description: "Number of pages for the results"
-        required: false
-        type: "string"
-        default: "0"
-      - name: "pageSize"
-        in: "query"
-        description: "Page size of the results"
-        required: false
-        type: "string"
-        default: "1000"
-      - name: "sortBy"
-        in: "query"
-        description: "Sorting the results based on this field"
-        required: false
-        type: "string"
-      - name: "sortType"
-        in: "query"
-        description: "Type of sorting (osc, desc)"
-        required: false
-        type: "string"
-      - name: "start_time"
-        in: "query"
-        description: "Date range param which is suportted from browser url"
-        required: false
-        type: "string"
-      - name: "end_time"
-        in: "query"
-        description: "Date range param which is supported from browser url"
-        required: false
-        type: "string"
-      - name: "clusters"
-        in: "query"
-        description: "filter for clusters (comma separated list)"
-        required: false
-        type: "string"
-      - name: "includeMessage"
-        in: "query"
-        description: "Include query which will query against message column"
-        required: false
-        type: "string"
-      - name: "excludeMessage"
-        in: "query"
-        description: "Exclude query which will query against message column"
-        required: false
-        type: "string"
-      - name: "mustBe"
-        in: "query"
-        description: "Include the components, comma separated values"
-        required: false
-        type: "string"
-      - name: "mustNot"
-        in: "query"
-        description: "Exclude the components, comma separated values"
-        required: false
-        type: "string"
-      - name: "includeQuery"
-        in: "query"
-        description: "Include the values in query result e.g.: [{message:*exception*}]"
-        required: false
-        type: "string"
-      - name: "excludeQuery"
-        in: "query"
-        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
-        required: false
-        type: "string"
-      - name: "from"
-        in: "query"
-        description: "Date range param, start date"
-        required: false
-        type: "string"
-      - name: "to"
-        in: "query"
-        description: "Date range param, end date"
-        required: false
-        type: "string"
-      - name: "userList"
-        in: "query"
-        description: "Filter for users (comma separated list)"
-        required: false
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AuditLogResponse"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "auditlogs"
-      summary: "Get the list of logs details"
-      description: ""
-      operationId: "getAuditLogsPost"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/AuditLogBodyRequest"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AuditLogResponse"
-      security:
-      - basicAuth: []
-    delete:
-      tags:
-      - "auditlogs"
-      summary: "Purge service logs based by criteria"
-      description: ""
-      operationId: "deleteAuditLogs"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/AuditLogBodyRequest"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/StatusMessage"
-      security:
-      - basicAuth: []
-  /audit/logs/components:
-    get:
-      tags:
-      - "auditlogs"
-      summary: "Get the list of audit components currently active or having data in\
-        \ Solr"
-      description: ""
-      operationId: "getAuditComponentsGet"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "clusters"
-        in: "query"
-        required: false
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "object"
-            additionalProperties:
-              type: "string"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "auditlogs"
-      summary: "Get the list of audit components currently active or having data in\
-        \ Solr"
-      description: ""
-      operationId: "getAuditComponentsPost"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/ClusterBodyRequest"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "object"
-            additionalProperties:
-              type: "string"
-      security:
-      - basicAuth: []
-  /audit/logs/bargraph:
-    get:
-      tags:
-      - "auditlogs"
-      summary: "Get the data required for line graph"
-      description: ""
-      operationId: "getAuditBarGraphDataGet"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "startIndex"
-        in: "query"
-        description: "Start index of the queried result"
-        required: false
-        type: "string"
-      - name: "page"
-        in: "query"
-        description: "Number of pages for the results"
-        required: false
-        type: "string"
-        default: "0"
-      - name: "pageSize"
-        in: "query"
-        description: "Page size of the results"
-        required: false
-        type: "string"
-        default: "1000"
-      - name: "sortBy"
-        in: "query"
-        description: "Sorting the results based on this field"
-        required: false
-        type: "string"
-      - name: "sortType"
-        in: "query"
-        description: "Type of sorting (osc, desc)"
-        required: false
-        type: "string"
-      - name: "start_time"
-        in: "query"
-        description: "Date range param which is suportted from browser url"
-        required: false
-        type: "string"
-      - name: "end_time"
-        in: "query"
-        description: "Date range param which is supported from browser url"
-        required: false
-        type: "string"
-      - name: "clusters"
-        in: "query"
-        description: "filter for clusters (comma separated list)"
-        required: false
-        type: "string"
-      - name: "includeMessage"
-        in: "query"
-        description: "Include query which will query against message column"
-        required: false
-        type: "string"
-      - name: "excludeMessage"
-        in: "query"
-        description: "Exclude query which will query against message column"
-        required: false
-        type: "string"
-      - name: "mustBe"
-        in: "query"
-        description: "Include the components, comma separated values"
-        required: false
-        type: "string"
-      - name: "mustNot"
-        in: "query"
-        description: "Exclude the components, comma separated values"
-        required: false
-        type: "string"
-      - name: "includeQuery"
-        in: "query"
-        description: "Include the values in query result e.g.: [{message:*exception*}]"
-        required: false
-        type: "string"
-      - name: "excludeQuery"
-        in: "query"
-        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
-        required: false
-        type: "string"
-      - name: "from"
-        in: "query"
-        description: "Date range param, start date"
-        required: false
-        type: "string"
-      - name: "to"
-        in: "query"
-        description: "Date range param, end date"
-        required: false
-        type: "string"
-      - name: "userList"
-        in: "query"
-        description: "Filter for users (comma separated list)"
-        required: false
-        type: "string"
-      - name: "unit"
-        in: "query"
-        description: "Aggregate the data with time gap as unit i.e 1MINUTE"
-        required: false
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/BarGraphDataListResponse"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "auditlogs"
-      summary: "Get the data required for line graph"
-      description: ""
-      operationId: "getAuditBarGraphDataPost"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/AuditBarGraphBodyRequest"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/BarGraphDataListResponse"
-      security:
-      - basicAuth: []
   /audit/logs/resources/{top}:
     get:
       tags:
@@ -525,6 +160,186 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+  /audit/logs/bargraph:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get the data required for line graph"
+      description: ""
+      operationId: "getAuditBarGraphDataGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "userList"
+        in: "query"
+        description: "Filter for users (comma separated list)"
+        required: false
+        type: "string"
+      - name: "unit"
+        in: "query"
+        description: "Aggregate the data with time gap as unit i.e 1MINUTE"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get the data required for line graph"
+      description: ""
+      operationId: "getAuditBarGraphDataPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/AuditBarGraphBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+  /audit/logs/components:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get the list of audit components currently active or having data in\
+        \ Solr"
+      description: ""
+      operationId: "getAuditComponentsGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusters"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "string"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get the list of audit components currently active or having data in\
+        \ Solr"
+      description: ""
+      operationId: "getAuditComponentsPost"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ClusterBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "string"
       security:
       - basicAuth: []
   /audit/logs/export:
@@ -826,6 +641,191 @@ paths:
               type: "string"
       security:
       - basicAuth: []
+  /audit/logs/schema/fields:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get list of schema fields in audit collection"
+      description: ""
+      operationId: "getSolrFieldListGet"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AuditFieldMetadataResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get list of schema fields in audit collection"
+      description: ""
+      operationId: "getSolrFieldListPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AuditFieldMetadataResponse"
+      security:
+      - basicAuth: []
+  /audit/logs:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get the list of logs details"
+      description: ""
+      operationId: "getAuditLogsGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "userList"
+        in: "query"
+        description: "Filter for users (comma separated list)"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AuditLogResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get the list of logs details"
+      description: ""
+      operationId: "getAuditLogsPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/AuditLogBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AuditLogResponse"
+      security:
+      - basicAuth: []
+    delete:
+      tags:
+      - "auditlogs"
+      summary: "Purge service logs based by criteria"
+      description: ""
+      operationId: "deleteAuditLogs"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/AuditLogBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/StatusMessage"
+      security:
+      - basicAuth: []
   /info/features:
     get:
       tags:
@@ -877,6 +877,81 @@ paths:
             type: "object"
             additionalProperties:
               type: "boolean"
+  /metadata:
+    get:
+      tags:
+      - "metadata"
+      summary: "Get metadata"
+      description: ""
+      operationId: "getMetadata"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "name"
+        in: "query"
+        description: "Name identifier of the metadata"
+        required: false
+        type: "string"
+      - name: "type"
+        in: "query"
+        description: "Type of the metadata"
+        required: true
+        type: "string"
+      - name: "userName"
+        in: "query"
+        description: "User name of the metadata"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/LogsearchMetaData"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "metadata"
+      summary: "Save metadata"
+      description: ""
+      operationId: "saveMetadata"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/LogsearchMetaData"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+      security:
+      - basicAuth: []
+    delete:
+      tags:
+      - "metadata"
+      summary: "Delete metadata"
+      description: ""
+      operationId: "deleteMetadata"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/LogsearchMetaData"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
   /metadata/list:
     get:
       tags:
@@ -953,81 +1028,6 @@ paths:
           type: "array"
           items:
             $ref: "#/definitions/LogsearchMetaData"
-      responses:
-        default:
-          description: "successful operation"
-      security:
-      - basicAuth: []
-  /metadata:
-    get:
-      tags:
-      - "metadata"
-      summary: "Get metadata"
-      description: ""
-      operationId: "getMetadata"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "name"
-        in: "query"
-        description: "Name identifier of the metadata"
-        required: false
-        type: "string"
-      - name: "type"
-        in: "query"
-        description: "Type of the metadata"
-        required: true
-        type: "string"
-      - name: "userName"
-        in: "query"
-        description: "User name of the metadata"
-        required: false
-        type: "string"
-      - name: "clusters"
-        in: "query"
-        description: "filter for clusters (comma separated list)"
-        required: false
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/LogsearchMetaData"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "metadata"
-      summary: "Save metadata"
-      description: ""
-      operationId: "saveMetadata"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/LogsearchMetaData"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "string"
-      security:
-      - basicAuth: []
-    delete:
-      tags:
-      - "metadata"
-      summary: "Delete metadata"
-      description: ""
-      operationId: "deleteMetadata"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/LogsearchMetaData"
       responses:
         default:
           description: "successful operation"
@@ -3157,6 +3157,29 @@ paths:
               type: "string"
       security:
       - basicAuth: []
+  /shipper/input/{clusterName}/services:
+    get:
+      tags:
+      - "shipper"
+      summary: "Get service names"
+      description: ""
+      operationId: "getServices"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusterName"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+      security:
+      - basicAuth: []
   /shipper/filters/{clusterName}/level:
     get:
       tags:
@@ -3199,29 +3222,6 @@ paths:
       responses:
         default:
           description: "successful operation"
-      security:
-      - basicAuth: []
-  /shipper/input/{clusterName}/services:
-    get:
-      tags:
-      - "shipper"
-      summary: "Get service names"
-      description: ""
-      operationId: "getServices"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "clusterName"
-        in: "path"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              type: "string"
       security:
       - basicAuth: []
   /shipper/input/{clusterName}/services/{serviceName}:
@@ -3415,213 +3415,6 @@ securityDefinitions:
   basicAuth:
     type: "basic"
 definitions:
-  AuditFieldMetadataResponse:
-    type: "object"
-    properties:
-      defaults:
-        type: "array"
-        items:
-          $ref: "#/definitions/FieldMetadata"
-      overrides:
-        type: "object"
-        additionalProperties:
-          type: "array"
-          items:
-            $ref: "#/definitions/FieldMetadata"
-  FieldMetadata:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      label:
-        type: "string"
-      filterable:
-        type: "boolean"
-      visible:
-        type: "boolean"
-  AuditLogData:
-    type: "object"
-    properties:
-      resource:
-        type: "string"
-      result:
-        type: "integer"
-        format: "int32"
-      text:
-        type: "string"
-      access:
-        type: "string"
-      reqContext:
-        type: "string"
-      policy:
-        type: "string"
-      sess:
-        type: "string"
-      proxyUsers:
-        type: "array"
-        items:
-          type: "string"
-      agent:
-        type: "string"
-      repo:
-        type: "string"
-      tags:
-        type: "array"
-        items:
-          type: "string"
-      agentHost:
-        type: "string"
-      cliIP:
-        type: "string"
-      cliType:
-        type: "string"
-      enforcer:
-        type: "string"
-      evtTime:
-        type: "string"
-        format: "date-time"
-      reason:
-        type: "string"
-      repoType:
-        type: "integer"
-        format: "int32"
-      reqData:
-        type: "string"
-      reqUser:
-        type: "string"
-      resType:
-        type: "string"
-      tags_str:
-        type: "string"
-      action:
-        type: "string"
-      logType:
-        type: "string"
-      id:
-        type: "string"
-      type:
-        type: "string"
-      file:
-        type: "string"
-      _version_:
-        type: "integer"
-        format: "int64"
-      log_message:
-        type: "string"
-      _ttl_:
-        type: "string"
-      _expire_at_:
-        type: "string"
-        format: "date-time"
-      _router_field_:
-        type: "integer"
-        format: "int32"
-      bundle_id:
-        type: "string"
-      seq_num:
-        type: "integer"
-        format: "int64"
-      message_md5:
-        type: "string"
-      cluster:
-        type: "string"
-      event_count:
-        type: "integer"
-        format: "int64"
-      event_md5:
-        type: "string"
-      event_dur_ms:
-        type: "integer"
-        format: "int64"
-      case_id:
-        type: "string"
-      logfile_line_number:
-        type: "integer"
-        format: "int32"
-  AuditLogResponse:
-    type: "object"
-    properties:
-      startIndex:
-        type: "integer"
-        format: "int32"
-      pageSize:
-        type: "integer"
-        format: "int32"
-      totalCount:
-        type: "integer"
-        format: "int64"
-      resultSize:
-        type: "integer"
-        format: "int32"
-      sortType:
-        type: "string"
-      sortBy:
-        type: "string"
-      queryTimeMS:
-        type: "integer"
-        format: "int64"
-      logList:
-        type: "array"
-        items:
-          $ref: "#/definitions/AuditLogData"
-      listSize:
-        type: "integer"
-        format: "int32"
-  AuditLogBodyRequest:
-    type: "object"
-    properties:
-      lastPage:
-        type: "boolean"
-      startIndex:
-        type: "string"
-      page:
-        type: "string"
-      pageSize:
-        type: "string"
-      sortBy:
-        type: "string"
-      sortType:
-        type: "string"
-      start_time:
-        type: "string"
-      end_time:
-        type: "string"
-      clusters:
-        type: "string"
-      includeMessage:
-        type: "string"
-      excludeMessage:
-        type: "string"
-      mustBe:
-        type: "string"
-      mustNot:
-        type: "string"
-      includeQuery:
-        type: "string"
-      excludeQuery:
-        type: "string"
-      from:
-        type: "string"
-      to:
-        type: "string"
-      userList:
-        type: "string"
-  StatusMessage:
-    type: "object"
-    properties:
-      status:
-        type: "integer"
-        format: "int32"
-      message:
-        type: "string"
-      statusCode:
-        type: "integer"
-        format: "int32"
-  ClusterBodyRequest:
-    type: "object"
-    properties:
-      clusters:
-        type: "string"
   BarGraphData:
     type: "object"
     properties:
@@ -3683,6 +3476,11 @@ definitions:
       userList:
         type: "string"
       unit:
+        type: "string"
+  ClusterBodyRequest:
+    type: "object"
+    properties:
+      clusters:
         type: "string"
   TopFieldAuditLogBodyRequest:
     type: "object"
@@ -3801,6 +3599,208 @@ definitions:
         type: "string"
       userList:
         type: "string"
+  AuditFieldMetadataResponse:
+    type: "object"
+    properties:
+      defaults:
+        type: "array"
+        items:
+          $ref: "#/definitions/FieldMetadata"
+      overrides:
+        type: "object"
+        additionalProperties:
+          type: "array"
+          items:
+            $ref: "#/definitions/FieldMetadata"
+  FieldMetadata:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      label:
+        type: "string"
+      filterable:
+        type: "boolean"
+      visible:
+        type: "boolean"
+  AuditLogData:
+    type: "object"
+    properties:
+      resource:
+        type: "string"
+      result:
+        type: "integer"
+        format: "int32"
+      sess:
+        type: "string"
+      policy:
+        type: "string"
+      reqContext:
+        type: "string"
+      access:
+        type: "string"
+      logType:
+        type: "string"
+      tags:
+        type: "array"
+        items:
+          type: "string"
+      text:
+        type: "string"
+      proxyUsers:
+        type: "array"
+        items:
+          type: "string"
+      action:
+        type: "string"
+      agent:
+        type: "string"
+      agentHost:
+        type: "string"
+      cliIP:
+        type: "string"
+      cliType:
+        type: "string"
+      enforcer:
+        type: "string"
+      evtTime:
+        type: "string"
+        format: "date-time"
+      reason:
+        type: "string"
+      repo:
+        type: "string"
+      repoType:
+        type: "integer"
+        format: "int32"
+      reqData:
+        type: "string"
+      reqUser:
+        type: "string"
+      resType:
+        type: "string"
+      tags_str:
+        type: "string"
+      id:
+        type: "string"
+      type:
+        type: "string"
+      file:
+        type: "string"
+      _version_:
+        type: "integer"
+        format: "int64"
+      bundle_id:
+        type: "string"
+      log_message:
+        type: "string"
+      case_id:
+        type: "string"
+      logfile_line_number:
+        type: "integer"
+        format: "int32"
+      seq_num:
+        type: "integer"
+        format: "int64"
+      message_md5:
+        type: "string"
+      cluster:
+        type: "string"
+      event_count:
+        type: "integer"
+        format: "int64"
+      event_md5:
+        type: "string"
+      event_dur_ms:
+        type: "integer"
+        format: "int64"
+      _ttl_:
+        type: "string"
+      _expire_at_:
+        type: "string"
+        format: "date-time"
+      _router_field_:
+        type: "integer"
+        format: "int32"
+  AuditLogResponse:
+    type: "object"
+    properties:
+      startIndex:
+        type: "integer"
+        format: "int32"
+      pageSize:
+        type: "integer"
+        format: "int32"
+      totalCount:
+        type: "integer"
+        format: "int64"
+      resultSize:
+        type: "integer"
+        format: "int32"
+      sortType:
+        type: "string"
+      sortBy:
+        type: "string"
+      queryTimeMS:
+        type: "integer"
+        format: "int64"
+      logList:
+        type: "array"
+        items:
+          $ref: "#/definitions/AuditLogData"
+      listSize:
+        type: "integer"
+        format: "int32"
+  AuditLogBodyRequest:
+    type: "object"
+    properties:
+      lastPage:
+        type: "boolean"
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      userList:
+        type: "string"
+  StatusMessage:
+    type: "object"
+    properties:
+      status:
+        type: "integer"
+        format: "int32"
+      message:
+        type: "string"
+      statusCode:
+        type: "integer"
+        format: "int32"
   LogsearchMetaData:
     type: "object"
     properties:
@@ -3848,11 +3848,11 @@ definitions:
       line_number:
         type: "integer"
         format: "int32"
-      group:
-        type: "string"
       level:
         type: "string"
       logger_name:
+        type: "string"
+      group:
         type: "string"
       logtime:
         type: "string"
@@ -3866,18 +3866,15 @@ definitions:
       _version_:
         type: "integer"
         format: "int64"
-      log_message:
-        type: "string"
-      _ttl_:
-        type: "string"
-      _expire_at_:
-        type: "string"
-        format: "date-time"
-      _router_field_:
-        type: "integer"
-        format: "int32"
       bundle_id:
         type: "string"
+      log_message:
+        type: "string"
+      case_id:
+        type: "string"
+      logfile_line_number:
+        type: "integer"
+        format: "int32"
       seq_num:
         type: "integer"
         format: "int64"
@@ -3893,9 +3890,12 @@ definitions:
       event_dur_ms:
         type: "integer"
         format: "int64"
-      case_id:
+      _ttl_:
         type: "string"
-      logfile_line_number:
+      _expire_at_:
+        type: "string"
+        format: "date-time"
+      _router_field_:
         type: "integer"
         format: "int32"
   ServiceLogResponse:

--- a/docs/api-docs/logsearch-swagger.yaml
+++ b/docs/api-docs/logsearch-swagger.yaml
@@ -826,23 +826,6 @@ paths:
               type: "string"
       security:
       - basicAuth: []
-  /info/features:
-    get:
-      tags:
-      - "info"
-      summary: "Get features list."
-      description: ""
-      operationId: "getFeatures"
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "object"
-            additionalProperties:
-              type: "object"
   /info:
     get:
       tags:
@@ -877,81 +860,23 @@ paths:
             type: "object"
             additionalProperties:
               type: "boolean"
-  /metadata:
+  /info/features:
     get:
       tags:
-      - "metadata"
-      summary: "Get metadata"
+      - "info"
+      summary: "Get features list."
       description: ""
-      operationId: "getMetadata"
+      operationId: "getFeatures"
       produces:
       - "application/json"
-      parameters:
-      - name: "name"
-        in: "query"
-        description: "Name identifier of the metadata"
-        required: false
-        type: "string"
-      - name: "type"
-        in: "query"
-        description: "Type of the metadata"
-        required: true
-        type: "string"
-      - name: "userName"
-        in: "query"
-        description: "User name of the metadata"
-        required: false
-        type: "string"
-      - name: "clusters"
-        in: "query"
-        description: "filter for clusters (comma separated list)"
-        required: false
-        type: "string"
+      parameters: []
       responses:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/LogsearchMetaData"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "metadata"
-      summary: "Save metadata"
-      description: ""
-      operationId: "saveMetadata"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/LogsearchMetaData"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "string"
-      security:
-      - basicAuth: []
-    delete:
-      tags:
-      - "metadata"
-      summary: "Delete metadata"
-      description: ""
-      operationId: "deleteMetadata"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/LogsearchMetaData"
-      responses:
-        default:
-          description: "successful operation"
-      security:
-      - basicAuth: []
+            type: "object"
+            additionalProperties:
+              type: "object"
   /metadata/list:
     get:
       tags:
@@ -1028,6 +953,81 @@ paths:
           type: "array"
           items:
             $ref: "#/definitions/LogsearchMetaData"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+  /metadata:
+    get:
+      tags:
+      - "metadata"
+      summary: "Get metadata"
+      description: ""
+      operationId: "getMetadata"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "name"
+        in: "query"
+        description: "Name identifier of the metadata"
+        required: false
+        type: "string"
+      - name: "type"
+        in: "query"
+        description: "Type of the metadata"
+        required: true
+        type: "string"
+      - name: "userName"
+        in: "query"
+        description: "User name of the metadata"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/LogsearchMetaData"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "metadata"
+      summary: "Save metadata"
+      description: ""
+      operationId: "saveMetadata"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/LogsearchMetaData"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+      security:
+      - basicAuth: []
+    delete:
+      tags:
+      - "metadata"
+      summary: "Delete metadata"
+      description: ""
+      operationId: "deleteMetadata"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/LogsearchMetaData"
       responses:
         default:
           description: "successful operation"
@@ -3180,50 +3180,6 @@ paths:
               type: "string"
       security:
       - basicAuth: []
-  /shipper/filters/{clusterName}/level:
-    get:
-      tags:
-      - "shipper"
-      summary: "Get log level filter"
-      description: ""
-      operationId: "getLogLevelFilters"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "clusterName"
-        in: "path"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/LSServerLogLevelFilterMap"
-      security:
-      - basicAuth: []
-    put:
-      tags:
-      - "shipper"
-      summary: "Update log level filter"
-      description: ""
-      operationId: "setLogLevelFilter"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/LSServerLogLevelFilterMap"
-      - name: "clusterName"
-        in: "path"
-        required: true
-        type: "string"
-      responses:
-        default:
-          description: "successful operation"
-      security:
-      - basicAuth: []
   /shipper/input/{clusterName}/services/{serviceName}:
     get:
       tags:
@@ -3328,6 +3284,50 @@ paths:
         description: "Input config json for logfeeder shipper"
         required: true
         type: "string"
+      - name: "clusterName"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+  /shipper/filters/{clusterName}/level:
+    get:
+      tags:
+      - "shipper"
+      summary: "Get log level filter"
+      description: ""
+      operationId: "getLogLevelFilters"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusterName"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/LSServerLogLevelFilterMap"
+      security:
+      - basicAuth: []
+    put:
+      tags:
+      - "shipper"
+      summary: "Update log level filter"
+      description: ""
+      operationId: "setLogLevelFilter"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/LSServerLogLevelFilterMap"
       - name: "clusterName"
         in: "path"
         required: true
@@ -3447,28 +3447,28 @@ definitions:
       result:
         type: "integer"
         format: "int32"
-      reqContext:
+      text:
         type: "string"
       policy:
         type: "string"
-      reason:
-        type: "string"
-      text:
+      reqContext:
         type: "string"
       access:
         type: "string"
+      reason:
+        type: "string"
       sess:
         type: "string"
+      tags:
+        type: "array"
+        items:
+          type: "string"
       proxyUsers:
         type: "array"
         items:
           type: "string"
       logType:
         type: "string"
-      tags:
-        type: "array"
-        items:
-          type: "string"
       action:
         type: "string"
       agent:
@@ -4684,39 +4684,6 @@ definitions:
         type: "string"
       clusters:
         type: "string"
-  LSServerLogLevelFilter:
-    type: "object"
-    required:
-    - "defaultLevels"
-    - "hosts"
-    - "label"
-    properties:
-      label:
-        type: "string"
-      hosts:
-        type: "array"
-        items:
-          type: "string"
-      defaultLevels:
-        type: "array"
-        items:
-          type: "string"
-      overrideLevels:
-        type: "array"
-        items:
-          type: "string"
-      expiryTime:
-        type: "string"
-        format: "date-time"
-  LSServerLogLevelFilterMap:
-    type: "object"
-    required:
-    - "filter"
-    properties:
-      filter:
-        type: "object"
-        additionalProperties:
-          $ref: "#/definitions/LSServerLogLevelFilter"
   LSServerConditions:
     type: "object"
     required:
@@ -4828,12 +4795,45 @@ definitions:
           $ref: "#/definitions/LSServerFilter"
   LSServerPostMapValuesList:
     type: "object"
+  LSServerLogLevelFilter:
+    type: "object"
+    required:
+    - "defaultLevels"
+    - "hosts"
+    - "label"
+    properties:
+      label:
+        type: "string"
+      hosts:
+        type: "array"
+        items:
+          type: "string"
+      defaultLevels:
+        type: "array"
+        items:
+          type: "string"
+      overrideLevels:
+        type: "array"
+        items:
+          type: "string"
+      expiryTime:
+        type: "string"
+        format: "date-time"
+  LSServerLogLevelFilterMap:
+    type: "object"
+    required:
+    - "filter"
+    properties:
+      filter:
+        type: "object"
+        additionalProperties:
+          $ref: "#/definitions/LSServerLogLevelFilter"
   SolrCollectionState:
     type: "object"
     properties:
       solrCollectionReady:
         type: "boolean"
-      configurationUploaded:
-        type: "boolean"
       znodeReady:
+        type: "boolean"
+      configurationUploaded:
         type: "boolean"

--- a/docs/api-docs/logsearch-swagger.yaml
+++ b/docs/api-docs/logsearch-swagger.yaml
@@ -19,6 +19,371 @@ schemes:
 - "http"
 - "https"
 paths:
+  /audit/logs/schema/fields:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get list of schema fields in audit collection"
+      description: ""
+      operationId: "getSolrFieldListGet"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AuditFieldMetadataResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get list of schema fields in audit collection"
+      description: ""
+      operationId: "getSolrFieldListPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AuditFieldMetadataResponse"
+      security:
+      - basicAuth: []
+  /audit/logs:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get the list of logs details"
+      description: ""
+      operationId: "getAuditLogsGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "userList"
+        in: "query"
+        description: "Filter for users (comma separated list)"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AuditLogResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get the list of logs details"
+      description: ""
+      operationId: "getAuditLogsPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/AuditLogBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AuditLogResponse"
+      security:
+      - basicAuth: []
+    delete:
+      tags:
+      - "auditlogs"
+      summary: "Purge service logs based by criteria"
+      description: ""
+      operationId: "deleteAuditLogs"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/AuditLogBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/StatusMessage"
+      security:
+      - basicAuth: []
+  /audit/logs/components:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get the list of audit components currently active or having data in\
+        \ Solr"
+      description: ""
+      operationId: "getAuditComponentsGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusters"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "string"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get the list of audit components currently active or having data in\
+        \ Solr"
+      description: ""
+      operationId: "getAuditComponentsPost"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ClusterBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "string"
+      security:
+      - basicAuth: []
+  /audit/logs/bargraph:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get the data required for line graph"
+      description: ""
+      operationId: "getAuditBarGraphDataGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "userList"
+        in: "query"
+        description: "Filter for users (comma separated list)"
+        required: false
+        type: "string"
+      - name: "unit"
+        in: "query"
+        description: "Aggregate the data with time gap as unit i.e 1MINUTE"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get the data required for line graph"
+      description: ""
+      operationId: "getAuditBarGraphDataPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/AuditBarGraphBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
   /audit/logs/resources/{top}:
     get:
       tags:
@@ -160,186 +525,6 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/BarGraphDataListResponse"
-      security:
-      - basicAuth: []
-  /audit/logs/bargraph:
-    get:
-      tags:
-      - "auditlogs"
-      summary: "Get the data required for line graph"
-      description: ""
-      operationId: "getAuditBarGraphDataGet"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "startIndex"
-        in: "query"
-        description: "Start index of the queried result"
-        required: false
-        type: "string"
-      - name: "page"
-        in: "query"
-        description: "Number of pages for the results"
-        required: false
-        type: "string"
-        default: "0"
-      - name: "pageSize"
-        in: "query"
-        description: "Page size of the results"
-        required: false
-        type: "string"
-        default: "1000"
-      - name: "sortBy"
-        in: "query"
-        description: "Sorting the results based on this field"
-        required: false
-        type: "string"
-      - name: "sortType"
-        in: "query"
-        description: "Type of sorting (osc, desc)"
-        required: false
-        type: "string"
-      - name: "start_time"
-        in: "query"
-        description: "Date range param which is suportted from browser url"
-        required: false
-        type: "string"
-      - name: "end_time"
-        in: "query"
-        description: "Date range param which is supported from browser url"
-        required: false
-        type: "string"
-      - name: "clusters"
-        in: "query"
-        description: "filter for clusters (comma separated list)"
-        required: false
-        type: "string"
-      - name: "includeMessage"
-        in: "query"
-        description: "Include query which will query against message column"
-        required: false
-        type: "string"
-      - name: "excludeMessage"
-        in: "query"
-        description: "Exclude query which will query against message column"
-        required: false
-        type: "string"
-      - name: "mustBe"
-        in: "query"
-        description: "Include the components, comma separated values"
-        required: false
-        type: "string"
-      - name: "mustNot"
-        in: "query"
-        description: "Exclude the components, comma separated values"
-        required: false
-        type: "string"
-      - name: "includeQuery"
-        in: "query"
-        description: "Include the values in query result e.g.: [{message:*exception*}]"
-        required: false
-        type: "string"
-      - name: "excludeQuery"
-        in: "query"
-        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
-        required: false
-        type: "string"
-      - name: "from"
-        in: "query"
-        description: "Date range param, start date"
-        required: false
-        type: "string"
-      - name: "to"
-        in: "query"
-        description: "Date range param, end date"
-        required: false
-        type: "string"
-      - name: "userList"
-        in: "query"
-        description: "Filter for users (comma separated list)"
-        required: false
-        type: "string"
-      - name: "unit"
-        in: "query"
-        description: "Aggregate the data with time gap as unit i.e 1MINUTE"
-        required: false
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/BarGraphDataListResponse"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "auditlogs"
-      summary: "Get the data required for line graph"
-      description: ""
-      operationId: "getAuditBarGraphDataPost"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/AuditBarGraphBodyRequest"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/BarGraphDataListResponse"
-      security:
-      - basicAuth: []
-  /audit/logs/components:
-    get:
-      tags:
-      - "auditlogs"
-      summary: "Get the list of audit components currently active or having data in\
-        \ Solr"
-      description: ""
-      operationId: "getAuditComponentsGet"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "clusters"
-        in: "query"
-        required: false
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "object"
-            additionalProperties:
-              type: "string"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "auditlogs"
-      summary: "Get the list of audit components currently active or having data in\
-        \ Solr"
-      description: ""
-      operationId: "getAuditComponentsPost"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/ClusterBodyRequest"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "object"
-            additionalProperties:
-              type: "string"
       security:
       - basicAuth: []
   /audit/logs/export:
@@ -639,191 +824,6 @@ paths:
             type: "array"
             items:
               type: "string"
-      security:
-      - basicAuth: []
-  /audit/logs/schema/fields:
-    get:
-      tags:
-      - "auditlogs"
-      summary: "Get list of schema fields in audit collection"
-      description: ""
-      operationId: "getSolrFieldListGet"
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AuditFieldMetadataResponse"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "auditlogs"
-      summary: "Get list of schema fields in audit collection"
-      description: ""
-      operationId: "getSolrFieldListPost"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AuditFieldMetadataResponse"
-      security:
-      - basicAuth: []
-  /audit/logs:
-    get:
-      tags:
-      - "auditlogs"
-      summary: "Get the list of logs details"
-      description: ""
-      operationId: "getAuditLogsGet"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "startIndex"
-        in: "query"
-        description: "Start index of the queried result"
-        required: false
-        type: "string"
-      - name: "page"
-        in: "query"
-        description: "Number of pages for the results"
-        required: false
-        type: "string"
-        default: "0"
-      - name: "pageSize"
-        in: "query"
-        description: "Page size of the results"
-        required: false
-        type: "string"
-        default: "1000"
-      - name: "sortBy"
-        in: "query"
-        description: "Sorting the results based on this field"
-        required: false
-        type: "string"
-      - name: "sortType"
-        in: "query"
-        description: "Type of sorting (osc, desc)"
-        required: false
-        type: "string"
-      - name: "start_time"
-        in: "query"
-        description: "Date range param which is suportted from browser url"
-        required: false
-        type: "string"
-      - name: "end_time"
-        in: "query"
-        description: "Date range param which is supported from browser url"
-        required: false
-        type: "string"
-      - name: "clusters"
-        in: "query"
-        description: "filter for clusters (comma separated list)"
-        required: false
-        type: "string"
-      - name: "includeMessage"
-        in: "query"
-        description: "Include query which will query against message column"
-        required: false
-        type: "string"
-      - name: "excludeMessage"
-        in: "query"
-        description: "Exclude query which will query against message column"
-        required: false
-        type: "string"
-      - name: "mustBe"
-        in: "query"
-        description: "Include the components, comma separated values"
-        required: false
-        type: "string"
-      - name: "mustNot"
-        in: "query"
-        description: "Exclude the components, comma separated values"
-        required: false
-        type: "string"
-      - name: "includeQuery"
-        in: "query"
-        description: "Include the values in query result e.g.: [{message:*exception*}]"
-        required: false
-        type: "string"
-      - name: "excludeQuery"
-        in: "query"
-        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
-        required: false
-        type: "string"
-      - name: "from"
-        in: "query"
-        description: "Date range param, start date"
-        required: false
-        type: "string"
-      - name: "to"
-        in: "query"
-        description: "Date range param, end date"
-        required: false
-        type: "string"
-      - name: "userList"
-        in: "query"
-        description: "Filter for users (comma separated list)"
-        required: false
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AuditLogResponse"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "auditlogs"
-      summary: "Get the list of logs details"
-      description: ""
-      operationId: "getAuditLogsPost"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/AuditLogBodyRequest"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/AuditLogResponse"
-      security:
-      - basicAuth: []
-    delete:
-      tags:
-      - "auditlogs"
-      summary: "Purge service logs based by criteria"
-      description: ""
-      operationId: "deleteAuditLogs"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/AuditLogBodyRequest"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/StatusMessage"
       security:
       - basicAuth: []
   /info/features:
@@ -3415,6 +3415,213 @@ securityDefinitions:
   basicAuth:
     type: "basic"
 definitions:
+  AuditFieldMetadataResponse:
+    type: "object"
+    properties:
+      defaults:
+        type: "array"
+        items:
+          $ref: "#/definitions/FieldMetadata"
+      overrides:
+        type: "object"
+        additionalProperties:
+          type: "array"
+          items:
+            $ref: "#/definitions/FieldMetadata"
+  FieldMetadata:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      label:
+        type: "string"
+      filterable:
+        type: "boolean"
+      visible:
+        type: "boolean"
+  AuditLogData:
+    type: "object"
+    properties:
+      resource:
+        type: "string"
+      result:
+        type: "integer"
+        format: "int32"
+      reqContext:
+        type: "string"
+      policy:
+        type: "string"
+      reason:
+        type: "string"
+      text:
+        type: "string"
+      access:
+        type: "string"
+      sess:
+        type: "string"
+      proxyUsers:
+        type: "array"
+        items:
+          type: "string"
+      logType:
+        type: "string"
+      tags:
+        type: "array"
+        items:
+          type: "string"
+      action:
+        type: "string"
+      agent:
+        type: "string"
+      agentHost:
+        type: "string"
+      cliIP:
+        type: "string"
+      cliType:
+        type: "string"
+      enforcer:
+        type: "string"
+      evtTime:
+        type: "string"
+        format: "date-time"
+      repo:
+        type: "string"
+      repoType:
+        type: "integer"
+        format: "int32"
+      reqData:
+        type: "string"
+      reqUser:
+        type: "string"
+      resType:
+        type: "string"
+      tags_str:
+        type: "string"
+      id:
+        type: "string"
+      type:
+        type: "string"
+      file:
+        type: "string"
+      _version_:
+        type: "integer"
+        format: "int64"
+      log_message:
+        type: "string"
+      bundle_id:
+        type: "string"
+      case_id:
+        type: "string"
+      logfile_line_number:
+        type: "integer"
+        format: "int32"
+      seq_num:
+        type: "integer"
+        format: "int64"
+      message_md5:
+        type: "string"
+      cluster:
+        type: "string"
+      event_count:
+        type: "integer"
+        format: "int64"
+      event_md5:
+        type: "string"
+      event_dur_ms:
+        type: "integer"
+        format: "int64"
+      _ttl_:
+        type: "string"
+      _expire_at_:
+        type: "string"
+        format: "date-time"
+      _router_field_:
+        type: "integer"
+        format: "int32"
+  AuditLogResponse:
+    type: "object"
+    properties:
+      startIndex:
+        type: "integer"
+        format: "int32"
+      pageSize:
+        type: "integer"
+        format: "int32"
+      totalCount:
+        type: "integer"
+        format: "int64"
+      resultSize:
+        type: "integer"
+        format: "int32"
+      sortType:
+        type: "string"
+      sortBy:
+        type: "string"
+      queryTimeMS:
+        type: "integer"
+        format: "int64"
+      logList:
+        type: "array"
+        items:
+          $ref: "#/definitions/AuditLogData"
+      listSize:
+        type: "integer"
+        format: "int32"
+  AuditLogBodyRequest:
+    type: "object"
+    properties:
+      lastPage:
+        type: "boolean"
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      userList:
+        type: "string"
+  StatusMessage:
+    type: "object"
+    properties:
+      status:
+        type: "integer"
+        format: "int32"
+      message:
+        type: "string"
+      statusCode:
+        type: "integer"
+        format: "int32"
+  ClusterBodyRequest:
+    type: "object"
+    properties:
+      clusters:
+        type: "string"
   BarGraphData:
     type: "object"
     properties:
@@ -3476,11 +3683,6 @@ definitions:
       userList:
         type: "string"
       unit:
-        type: "string"
-  ClusterBodyRequest:
-    type: "object"
-    properties:
-      clusters:
         type: "string"
   TopFieldAuditLogBodyRequest:
     type: "object"
@@ -3599,208 +3801,6 @@ definitions:
         type: "string"
       userList:
         type: "string"
-  AuditFieldMetadataResponse:
-    type: "object"
-    properties:
-      defaults:
-        type: "array"
-        items:
-          $ref: "#/definitions/FieldMetadata"
-      overrides:
-        type: "object"
-        additionalProperties:
-          type: "array"
-          items:
-            $ref: "#/definitions/FieldMetadata"
-  FieldMetadata:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      label:
-        type: "string"
-      filterable:
-        type: "boolean"
-      visible:
-        type: "boolean"
-  AuditLogData:
-    type: "object"
-    properties:
-      resource:
-        type: "string"
-      result:
-        type: "integer"
-        format: "int32"
-      sess:
-        type: "string"
-      policy:
-        type: "string"
-      reqContext:
-        type: "string"
-      access:
-        type: "string"
-      logType:
-        type: "string"
-      tags:
-        type: "array"
-        items:
-          type: "string"
-      text:
-        type: "string"
-      proxyUsers:
-        type: "array"
-        items:
-          type: "string"
-      action:
-        type: "string"
-      agent:
-        type: "string"
-      agentHost:
-        type: "string"
-      cliIP:
-        type: "string"
-      cliType:
-        type: "string"
-      enforcer:
-        type: "string"
-      evtTime:
-        type: "string"
-        format: "date-time"
-      reason:
-        type: "string"
-      repo:
-        type: "string"
-      repoType:
-        type: "integer"
-        format: "int32"
-      reqData:
-        type: "string"
-      reqUser:
-        type: "string"
-      resType:
-        type: "string"
-      tags_str:
-        type: "string"
-      id:
-        type: "string"
-      type:
-        type: "string"
-      file:
-        type: "string"
-      _version_:
-        type: "integer"
-        format: "int64"
-      bundle_id:
-        type: "string"
-      log_message:
-        type: "string"
-      case_id:
-        type: "string"
-      logfile_line_number:
-        type: "integer"
-        format: "int32"
-      seq_num:
-        type: "integer"
-        format: "int64"
-      message_md5:
-        type: "string"
-      cluster:
-        type: "string"
-      event_count:
-        type: "integer"
-        format: "int64"
-      event_md5:
-        type: "string"
-      event_dur_ms:
-        type: "integer"
-        format: "int64"
-      _ttl_:
-        type: "string"
-      _expire_at_:
-        type: "string"
-        format: "date-time"
-      _router_field_:
-        type: "integer"
-        format: "int32"
-  AuditLogResponse:
-    type: "object"
-    properties:
-      startIndex:
-        type: "integer"
-        format: "int32"
-      pageSize:
-        type: "integer"
-        format: "int32"
-      totalCount:
-        type: "integer"
-        format: "int64"
-      resultSize:
-        type: "integer"
-        format: "int32"
-      sortType:
-        type: "string"
-      sortBy:
-        type: "string"
-      queryTimeMS:
-        type: "integer"
-        format: "int64"
-      logList:
-        type: "array"
-        items:
-          $ref: "#/definitions/AuditLogData"
-      listSize:
-        type: "integer"
-        format: "int32"
-  AuditLogBodyRequest:
-    type: "object"
-    properties:
-      lastPage:
-        type: "boolean"
-      startIndex:
-        type: "string"
-      page:
-        type: "string"
-      pageSize:
-        type: "string"
-      sortBy:
-        type: "string"
-      sortType:
-        type: "string"
-      start_time:
-        type: "string"
-      end_time:
-        type: "string"
-      clusters:
-        type: "string"
-      includeMessage:
-        type: "string"
-      excludeMessage:
-        type: "string"
-      mustBe:
-        type: "string"
-      mustNot:
-        type: "string"
-      includeQuery:
-        type: "string"
-      excludeQuery:
-        type: "string"
-      from:
-        type: "string"
-      to:
-        type: "string"
-      userList:
-        type: "string"
-  StatusMessage:
-    type: "object"
-    properties:
-      status:
-        type: "integer"
-        format: "int32"
-      message:
-        type: "string"
-      statusCode:
-        type: "integer"
-        format: "int32"
   LogsearchMetaData:
     type: "object"
     properties:
@@ -3866,9 +3866,9 @@ definitions:
       _version_:
         type: "integer"
         format: "int64"
-      bundle_id:
-        type: "string"
       log_message:
+        type: "string"
+      bundle_id:
         type: "string"
       case_id:
         type: "string"
@@ -4831,9 +4831,9 @@ definitions:
   SolrCollectionState:
     type: "object"
     properties:
-      znodeReady:
-        type: "boolean"
       solrCollectionReady:
         type: "boolean"
       configurationUploaded:
+        type: "boolean"
+      znodeReady:
         type: "boolean"

--- a/docs/api-docs/logsearch-swagger.yaml
+++ b/docs/api-docs/logsearch-swagger.yaml
@@ -19,6 +19,172 @@ schemes:
 - "http"
 - "https"
 paths:
+  /audit/logs/serviceload:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "The graph for showing the top users accessing the services"
+      description: ""
+      operationId: "getServiceLoadGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "userList"
+        in: "query"
+        description: "Filter for users (comma separated list)"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "The graph for showing the top users accessing the services"
+      description: ""
+      operationId: "getServiceLoadPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/AuditServiceLoadBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+  /audit/logs/clusters:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get all of the clusters for audit logs"
+      description: ""
+      operationId: "getClustersForAuditLogGet"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get all of the clusters for audit logs"
+      description: ""
+      operationId: "getClustersForAuditLogPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+      security:
+      - basicAuth: []
   /audit/logs/schema/fields:
     get:
       tags:
@@ -660,140 +826,13 @@ paths:
           description: "successful operation"
       security:
       - basicAuth: []
-  /audit/logs/serviceload:
+  /info/features:
     get:
       tags:
-      - "auditlogs"
-      summary: "The graph for showing the top users accessing the services"
+      - "info"
+      summary: "Get features list."
       description: ""
-      operationId: "getServiceLoadGet"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "startIndex"
-        in: "query"
-        description: "Start index of the queried result"
-        required: false
-        type: "string"
-      - name: "page"
-        in: "query"
-        description: "Number of pages for the results"
-        required: false
-        type: "string"
-        default: "0"
-      - name: "pageSize"
-        in: "query"
-        description: "Page size of the results"
-        required: false
-        type: "string"
-        default: "1000"
-      - name: "sortBy"
-        in: "query"
-        description: "Sorting the results based on this field"
-        required: false
-        type: "string"
-      - name: "sortType"
-        in: "query"
-        description: "Type of sorting (osc, desc)"
-        required: false
-        type: "string"
-      - name: "start_time"
-        in: "query"
-        description: "Date range param which is suportted from browser url"
-        required: false
-        type: "string"
-      - name: "end_time"
-        in: "query"
-        description: "Date range param which is supported from browser url"
-        required: false
-        type: "string"
-      - name: "clusters"
-        in: "query"
-        description: "filter for clusters (comma separated list)"
-        required: false
-        type: "string"
-      - name: "includeMessage"
-        in: "query"
-        description: "Include query which will query against message column"
-        required: false
-        type: "string"
-      - name: "excludeMessage"
-        in: "query"
-        description: "Exclude query which will query against message column"
-        required: false
-        type: "string"
-      - name: "mustBe"
-        in: "query"
-        description: "Include the components, comma separated values"
-        required: false
-        type: "string"
-      - name: "mustNot"
-        in: "query"
-        description: "Exclude the components, comma separated values"
-        required: false
-        type: "string"
-      - name: "includeQuery"
-        in: "query"
-        description: "Include the values in query result e.g.: [{message:*exception*}]"
-        required: false
-        type: "string"
-      - name: "excludeQuery"
-        in: "query"
-        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
-        required: false
-        type: "string"
-      - name: "from"
-        in: "query"
-        description: "Date range param, start date"
-        required: false
-        type: "string"
-      - name: "to"
-        in: "query"
-        description: "Date range param, end date"
-        required: false
-        type: "string"
-      - name: "userList"
-        in: "query"
-        description: "Filter for users (comma separated list)"
-        required: false
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/BarGraphDataListResponse"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "auditlogs"
-      summary: "The graph for showing the top users accessing the services"
-      description: ""
-      operationId: "getServiceLoadPost"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/AuditServiceLoadBodyRequest"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/BarGraphDataListResponse"
-      security:
-      - basicAuth: []
-  /audit/logs/clusters:
-    get:
-      tags:
-      - "auditlogs"
-      summary: "Get all of the clusters for audit logs"
-      description: ""
-      operationId: "getClustersForAuditLogGet"
+      operationId: "getFeatures"
       produces:
       - "application/json"
       parameters: []
@@ -801,31 +840,9 @@ paths:
         200:
           description: "successful operation"
           schema:
-            type: "array"
-            items:
-              type: "string"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "auditlogs"
-      summary: "Get all of the clusters for audit logs"
-      description: ""
-      operationId: "getClustersForAuditLogPost"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              type: "string"
-      security:
-      - basicAuth: []
+            type: "object"
+            additionalProperties:
+              type: "object"
   /info:
     get:
       tags:
@@ -860,23 +877,81 @@ paths:
             type: "object"
             additionalProperties:
               type: "boolean"
-  /info/features:
+  /metadata:
     get:
       tags:
-      - "info"
-      summary: "Get features list."
+      - "metadata"
+      summary: "Get metadata"
       description: ""
-      operationId: "getFeatures"
+      operationId: "getMetadata"
       produces:
       - "application/json"
-      parameters: []
+      parameters:
+      - name: "name"
+        in: "query"
+        description: "Name identifier of the metadata"
+        required: false
+        type: "string"
+      - name: "type"
+        in: "query"
+        description: "Type of the metadata"
+        required: true
+        type: "string"
+      - name: "userName"
+        in: "query"
+        description: "User name of the metadata"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
       responses:
         200:
           description: "successful operation"
           schema:
-            type: "object"
-            additionalProperties:
-              type: "object"
+            $ref: "#/definitions/LogsearchMetaData"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "metadata"
+      summary: "Save metadata"
+      description: ""
+      operationId: "saveMetadata"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/LogsearchMetaData"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+      security:
+      - basicAuth: []
+    delete:
+      tags:
+      - "metadata"
+      summary: "Delete metadata"
+      description: ""
+      operationId: "deleteMetadata"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/LogsearchMetaData"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
   /metadata/list:
     get:
       tags:
@@ -953,81 +1028,6 @@ paths:
           type: "array"
           items:
             $ref: "#/definitions/LogsearchMetaData"
-      responses:
-        default:
-          description: "successful operation"
-      security:
-      - basicAuth: []
-  /metadata:
-    get:
-      tags:
-      - "metadata"
-      summary: "Get metadata"
-      description: ""
-      operationId: "getMetadata"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "name"
-        in: "query"
-        description: "Name identifier of the metadata"
-        required: false
-        type: "string"
-      - name: "type"
-        in: "query"
-        description: "Type of the metadata"
-        required: true
-        type: "string"
-      - name: "userName"
-        in: "query"
-        description: "User name of the metadata"
-        required: false
-        type: "string"
-      - name: "clusters"
-        in: "query"
-        description: "filter for clusters (comma separated list)"
-        required: false
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/LogsearchMetaData"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "metadata"
-      summary: "Save metadata"
-      description: ""
-      operationId: "saveMetadata"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/LogsearchMetaData"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "string"
-      security:
-      - basicAuth: []
-    delete:
-      tags:
-      - "metadata"
-      summary: "Delete metadata"
-      description: ""
-      operationId: "deleteMetadata"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/LogsearchMetaData"
       responses:
         default:
           description: "successful operation"
@@ -3157,29 +3157,6 @@ paths:
               type: "string"
       security:
       - basicAuth: []
-  /shipper/input/{clusterName}/services:
-    get:
-      tags:
-      - "shipper"
-      summary: "Get service names"
-      description: ""
-      operationId: "getServices"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "clusterName"
-        in: "path"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              type: "string"
-      security:
-      - basicAuth: []
   /shipper/input/{clusterName}/services/{serviceName}:
     get:
       tags:
@@ -3259,38 +3236,27 @@ paths:
           description: "successful operation"
       security:
       - basicAuth: []
-  /shipper/input/{clusterName}/test:
-    post:
+  /shipper/input/{clusterName}/services:
+    get:
       tags:
       - "shipper"
-      summary: "Test shipper config"
+      summary: "Get service names"
       description: ""
-      operationId: "testShipperConfig"
+      operationId: "getServices"
       produces:
       - "application/json"
       parameters:
-      - name: "logId"
-        in: "formData"
-        description: "Id of the log component"
-        required: true
-        type: "string"
-      - name: "testEntry"
-        in: "formData"
-        description: "Log sample for testing"
-        required: true
-        type: "string"
-      - name: "shipperConfig"
-        in: "formData"
-        description: "Input config json for logfeeder shipper"
-        required: true
-        type: "string"
       - name: "clusterName"
         in: "path"
         required: true
         type: "string"
       responses:
-        default:
+        200:
           description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
       security:
       - basicAuth: []
   /shipper/filters/{clusterName}/level:
@@ -3328,6 +3294,40 @@ paths:
         required: false
         schema:
           $ref: "#/definitions/LSServerLogLevelFilterMap"
+      - name: "clusterName"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+  /shipper/input/{clusterName}/test:
+    post:
+      tags:
+      - "shipper"
+      summary: "Test shipper config"
+      description: ""
+      operationId: "testShipperConfig"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "logId"
+        in: "formData"
+        description: "Id of the log component"
+        required: true
+        type: "string"
+      - name: "testEntry"
+        in: "formData"
+        description: "Log sample for testing"
+        required: true
+        type: "string"
+      - name: "shipperConfig"
+        in: "formData"
+        description: "Input config json for logfeeder shipper"
+        required: true
+        type: "string"
       - name: "clusterName"
         in: "path"
         required: true
@@ -3415,6 +3415,66 @@ securityDefinitions:
   basicAuth:
     type: "basic"
 definitions:
+  BarGraphData:
+    type: "object"
+    properties:
+      dataCount:
+        type: "array"
+        items:
+          $ref: "#/definitions/NameValueData"
+      name:
+        type: "string"
+  BarGraphDataListResponse:
+    type: "object"
+    properties:
+      graphData:
+        type: "array"
+        items:
+          $ref: "#/definitions/BarGraphData"
+  NameValueData:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      value:
+        type: "string"
+  AuditServiceLoadBodyRequest:
+    type: "object"
+    properties:
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      userList:
+        type: "string"
   AuditFieldMetadataResponse:
     type: "object"
     properties:
@@ -3447,29 +3507,29 @@ definitions:
       result:
         type: "integer"
         format: "int32"
-      text:
-        type: "string"
       policy:
         type: "string"
       reqContext:
         type: "string"
-      access:
+      action:
         type: "string"
       reason:
         type: "string"
-      sess:
+      text:
         type: "string"
-      tags:
-        type: "array"
-        items:
-          type: "string"
+      access:
+        type: "string"
       proxyUsers:
         type: "array"
         items:
           type: "string"
       logType:
         type: "string"
-      action:
+      tags:
+        type: "array"
+        items:
+          type: "string"
+      sess:
         type: "string"
       agent:
         type: "string"
@@ -3622,29 +3682,6 @@ definitions:
     properties:
       clusters:
         type: "string"
-  BarGraphData:
-    type: "object"
-    properties:
-      dataCount:
-        type: "array"
-        items:
-          $ref: "#/definitions/NameValueData"
-      name:
-        type: "string"
-  BarGraphDataListResponse:
-    type: "object"
-    properties:
-      graphData:
-        type: "array"
-        items:
-          $ref: "#/definitions/BarGraphData"
-  NameValueData:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      value:
-        type: "string"
   AuditBarGraphBodyRequest:
     type: "object"
     properties:
@@ -3763,43 +3800,6 @@ definitions:
       userList:
         type: "string"
       format:
-        type: "string"
-  AuditServiceLoadBodyRequest:
-    type: "object"
-    properties:
-      startIndex:
-        type: "string"
-      page:
-        type: "string"
-      pageSize:
-        type: "string"
-      sortBy:
-        type: "string"
-      sortType:
-        type: "string"
-      start_time:
-        type: "string"
-      end_time:
-        type: "string"
-      clusters:
-        type: "string"
-      includeMessage:
-        type: "string"
-      excludeMessage:
-        type: "string"
-      mustBe:
-        type: "string"
-      mustNot:
-        type: "string"
-      includeQuery:
-        type: "string"
-      excludeQuery:
-        type: "string"
-      from:
-        type: "string"
-      to:
-        type: "string"
-      userList:
         type: "string"
   LogsearchMetaData:
     type: "object"
@@ -4831,9 +4831,9 @@ definitions:
   SolrCollectionState:
     type: "object"
     properties:
-      solrCollectionReady:
-        type: "boolean"
       znodeReady:
+        type: "boolean"
+      solrCollectionReady:
         type: "boolean"
       configurationUploaded:
         type: "boolean"

--- a/docs/api-docs/logsearch-swagger.yaml
+++ b/docs/api-docs/logsearch-swagger.yaml
@@ -1,0 +1,4839 @@
+---
+swagger: "2.0"
+info:
+  description: "Log aggregation, analysis, and visualization."
+  version: "1.0.0"
+  title: "Log Search REST API"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+basePath: "/api/v1"
+tags:
+- name: "auditlogs"
+- name: "info"
+- name: "metadata"
+- name: "servicelogs"
+- name: "shipper"
+- name: "status"
+schemes:
+- "http"
+- "https"
+paths:
+  /audit/logs/schema/fields:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get list of schema fields in audit collection"
+      description: ""
+      operationId: "getSolrFieldListGet"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AuditFieldMetadataResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get list of schema fields in audit collection"
+      description: ""
+      operationId: "getSolrFieldListPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AuditFieldMetadataResponse"
+      security:
+      - basicAuth: []
+  /audit/logs:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get the list of logs details"
+      description: ""
+      operationId: "getAuditLogsGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "userList"
+        in: "query"
+        description: "Filter for users (comma separated list)"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AuditLogResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get the list of logs details"
+      description: ""
+      operationId: "getAuditLogsPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/AuditLogBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/AuditLogResponse"
+      security:
+      - basicAuth: []
+    delete:
+      tags:
+      - "auditlogs"
+      summary: "Purge service logs based by criteria"
+      description: ""
+      operationId: "deleteAuditLogs"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/AuditLogBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/StatusMessage"
+      security:
+      - basicAuth: []
+  /audit/logs/components:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get the list of audit components currently active or having data in\
+        \ Solr"
+      description: ""
+      operationId: "getAuditComponentsGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusters"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "string"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get the list of audit components currently active or having data in\
+        \ Solr"
+      description: ""
+      operationId: "getAuditComponentsPost"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ClusterBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "string"
+      security:
+      - basicAuth: []
+  /audit/logs/bargraph:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get the data required for line graph"
+      description: ""
+      operationId: "getAuditBarGraphDataGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "userList"
+        in: "query"
+        description: "Filter for users (comma separated list)"
+        required: false
+        type: "string"
+      - name: "unit"
+        in: "query"
+        description: "Aggregate the data with time gap as unit i.e 1MINUTE"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get the data required for line graph"
+      description: ""
+      operationId: "getAuditBarGraphDataPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/AuditBarGraphBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+  /audit/logs/resources/{top}:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get the top audit resource count (grouped by type)"
+      description: ""
+      operationId: "getResourcesGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "field"
+        in: "query"
+        description: "Get values for particular field"
+        required: true
+        type: "string"
+      - name: "userList"
+        in: "query"
+        description: "Filter for users (comma separated list)"
+        required: false
+        type: "string"
+      - name: "top"
+        in: "path"
+        description: "Number that defines how many top element you would like to see."
+        required: true
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get the top audit resource count (grouped by type)"
+      description: ""
+      operationId: "getResourcesPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/TopFieldAuditLogBodyRequest"
+      - name: "top"
+        in: "path"
+        required: true
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+  /audit/logs/export:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Export the tables shown on Audit tab"
+      description: ""
+      operationId: "exportUserTableToTextFileGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "field"
+        in: "query"
+        description: "Get values for particular field"
+        required: true
+        type: "string"
+      - name: "userList"
+        in: "query"
+        description: "Filter for users (comma separated list)"
+        required: false
+        type: "string"
+      - name: "format"
+        in: "query"
+        description: "File Export format, can be 'txt' or 'json'"
+        required: false
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Export the tables shown on Audit tab"
+      description: ""
+      operationId: "exportUserTableToTextFilePost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/UserExportBodyRequest"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+  /audit/logs/serviceload:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "The graph for showing the top users accessing the services"
+      description: ""
+      operationId: "getServiceLoadGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "userList"
+        in: "query"
+        description: "Filter for users (comma separated list)"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "The graph for showing the top users accessing the services"
+      description: ""
+      operationId: "getServiceLoadPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/AuditServiceLoadBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+  /audit/logs/clusters:
+    get:
+      tags:
+      - "auditlogs"
+      summary: "Get all of the clusters for audit logs"
+      description: ""
+      operationId: "getClustersForAuditLogGet"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "auditlogs"
+      summary: "Get all of the clusters for audit logs"
+      description: ""
+      operationId: "getClustersForAuditLogPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+      security:
+      - basicAuth: []
+  /info/features:
+    get:
+      tags:
+      - "info"
+      summary: "Get features list."
+      description: ""
+      operationId: "getFeatures"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "object"
+  /info:
+    get:
+      tags:
+      - "info"
+      summary: "Get application details."
+      description: ""
+      operationId: "getApplicationInfo"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "string"
+  /info/features/auth:
+    get:
+      tags:
+      - "info"
+      summary: "Get authentication details."
+      description: ""
+      operationId: "getAuthInfo"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "boolean"
+  /metadata/list:
+    get:
+      tags:
+      - "metadata"
+      summary: "Get metadata list"
+      description: ""
+      operationId: "getMetadataList"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "name"
+        in: "query"
+        description: "Name identifier of the metadata"
+        required: false
+        type: "string"
+      - name: "type"
+        in: "query"
+        description: "Type of the metadata"
+        required: true
+        type: "string"
+      - name: "userName"
+        in: "query"
+        description: "User name of the metadata"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/LogsearchMetaData"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "metadata"
+      summary: "Save metadata list"
+      description: ""
+      operationId: "saveMetadataList"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/LogsearchMetaData"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+      security:
+      - basicAuth: []
+    delete:
+      tags:
+      - "metadata"
+      summary: "Delete metadata list"
+      description: ""
+      operationId: "deleteMetadataList"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/LogsearchMetaData"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+  /metadata:
+    get:
+      tags:
+      - "metadata"
+      summary: "Get metadata"
+      description: ""
+      operationId: "getMetadata"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "name"
+        in: "query"
+        description: "Name identifier of the metadata"
+        required: false
+        type: "string"
+      - name: "type"
+        in: "query"
+        description: "Type of the metadata"
+        required: true
+        type: "string"
+      - name: "userName"
+        in: "query"
+        description: "User name of the metadata"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/LogsearchMetaData"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "metadata"
+      summary: "Save metadata"
+      description: ""
+      operationId: "saveMetadata"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/LogsearchMetaData"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+      security:
+      - basicAuth: []
+    delete:
+      tags:
+      - "metadata"
+      summary: "Delete metadata"
+      description: ""
+      operationId: "deleteMetadata"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/LogsearchMetaData"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+  /service/logs/components:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get the list of service components currently active or having data\
+        \ in Solr"
+      description: ""
+      operationId: "getComponents"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusters"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ServiceComponentMetadataWrapper"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get the list of service components currently active or having data\
+        \ in Solr"
+      description: ""
+      operationId: "getComponents"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ClusterBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ServiceComponentMetadataWrapper"
+      security:
+      - basicAuth: []
+  /service/logs:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Searching logs entry"
+      description: ""
+      operationId: "searchServiceLogsGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "level"
+        in: "query"
+        description: "filter for log level"
+        required: false
+        type: "string"
+      - name: "host_name"
+        in: "query"
+        description: "Host name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "component_name"
+        in: "query"
+        description: "Component name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "file_name"
+        in: "query"
+        description: "File name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "bundle_id"
+        in: "query"
+        description: "filter for host"
+        required: false
+        type: "string"
+      - name: "hostList"
+        in: "query"
+        description: "filter for hosts"
+        required: false
+        type: "string"
+      - name: "find"
+        in: "query"
+        description: "Finding particular text on subsequent pages in case of table\
+          \ view with pagination"
+        required: false
+        type: "string"
+      - name: "sourceLogId"
+        in: "query"
+        description: "fetch the record set having that log Id"
+        required: false
+        type: "string"
+      - name: "keywordType"
+        in: "query"
+        description: "Serching the find param value in previous or next in paginated\
+          \ table"
+        required: false
+        type: "string"
+      - name: "token"
+        in: "query"
+        description: "unique number used along with FIND_D. The request can be canceled\
+          \ using this token"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ServiceLogResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Searching logs entry"
+      description: ""
+      operationId: "searchServiceLogsPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ServiceLogBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ServiceLogResponse"
+      security:
+      - basicAuth: []
+    delete:
+      tags:
+      - "servicelogs"
+      summary: "Purge service logs based by criteria"
+      description: ""
+      operationId: "deleteServiceLogs"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ServiceLogBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/StatusMessage"
+      security:
+      - basicAuth: []
+  /service/logs/hosts:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get the list of service hosts currently active or having data in Solr"
+      description: ""
+      operationId: "getHostsGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusters"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/GroupListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get the list of service hosts currently active or having data in Solr"
+      description: ""
+      operationId: "getHostsPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ClusterBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/GroupListResponse"
+      security:
+      - basicAuth: []
+  /service/logs/aggregated:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "not required"
+      description: ""
+      operationId: "getAggregatedInfoGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "level"
+        in: "query"
+        description: "filter for log level"
+        required: false
+        type: "string"
+      - name: "host_name"
+        in: "query"
+        description: "Host name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "component_name"
+        in: "query"
+        description: "Component name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "file_name"
+        in: "query"
+        description: "File name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "bundle_id"
+        in: "query"
+        description: "filter for host"
+        required: false
+        type: "string"
+      - name: "hostList"
+        in: "query"
+        description: "filter for hosts"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/GraphDataListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "not required"
+      description: ""
+      operationId: "getAggregatedInfoPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ServiceLogAggregatedInfoBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/GraphDataListResponse"
+      security:
+      - basicAuth: []
+  /service/logs/components/count:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get components with their counts"
+      description: ""
+      operationId: "getComponentsCountGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusters"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/CountDataListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get components with their counts"
+      description: ""
+      operationId: "getComponentsCountPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ClusterBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/CountDataListResponse"
+      security:
+      - basicAuth: []
+  /service/logs/hosts/count:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get hosts with their counts"
+      description: ""
+      operationId: "getHostsCountGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusters"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/CountDataListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get hosts with their counts"
+      description: ""
+      operationId: "getHostsCountPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ClusterBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/CountDataListResponse"
+      security:
+      - basicAuth: []
+  /service/logs/tree:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get host and compoenets hierarchy with log counts"
+      description: ""
+      operationId: "getTreeExtensionGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "level"
+        in: "query"
+        description: "filter for log level"
+        required: false
+        type: "string"
+      - name: "host_name"
+        in: "query"
+        description: "Host name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "component_name"
+        in: "query"
+        description: "Component name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "file_name"
+        in: "query"
+        description: "File name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "bundle_id"
+        in: "query"
+        description: "filter for host"
+        required: false
+        type: "string"
+      - name: "hostList"
+        in: "query"
+        description: "filter for hosts"
+        required: false
+        type: "string"
+      - name: "find"
+        in: "query"
+        description: "Finding particular text on subsequent pages in case of table\
+          \ view with pagination"
+        required: false
+        type: "string"
+      - name: "sourceLogId"
+        in: "query"
+        description: "fetch the record set having that log Id"
+        required: false
+        type: "string"
+      - name: "keywordType"
+        in: "query"
+        description: "Serching the find param value in previous or next in paginated\
+          \ table"
+        required: false
+        type: "string"
+      - name: "token"
+        in: "query"
+        description: "unique number used along with FIND_D. The request can be canceled\
+          \ using this token"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/NodeListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get host and compoenets hierarchy with log counts"
+      description: ""
+      operationId: "getTreeExtensionPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ServiceLogHostComponentBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/NodeListResponse"
+      security:
+      - basicAuth: []
+  /service/logs/levels/counts:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get Log levels with their counts"
+      description: ""
+      operationId: "getLogsLevelCountGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "level"
+        in: "query"
+        description: "filter for log level"
+        required: false
+        type: "string"
+      - name: "host_name"
+        in: "query"
+        description: "Host name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "component_name"
+        in: "query"
+        description: "Component name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "file_name"
+        in: "query"
+        description: "File name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "bundle_id"
+        in: "query"
+        description: "filter for host"
+        required: false
+        type: "string"
+      - name: "hostList"
+        in: "query"
+        description: "filter for hosts"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/NameValueDataListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get Log levels with their counts"
+      description: ""
+      operationId: "getLogsLevelCountPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ServiceLogLevelCountBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/NameValueDataListResponse"
+      security:
+      - basicAuth: []
+  /service/logs/histogram:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get data for histogram"
+      description: ""
+      operationId: "getHistogramDataGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "level"
+        in: "query"
+        description: "filter for log level"
+        required: false
+        type: "string"
+      - name: "host_name"
+        in: "query"
+        description: "Host name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "component_name"
+        in: "query"
+        description: "Component name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "file_name"
+        in: "query"
+        description: "File name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "bundle_id"
+        in: "query"
+        description: "filter for host"
+        required: false
+        type: "string"
+      - name: "hostList"
+        in: "query"
+        description: "filter for hosts"
+        required: false
+        type: "string"
+      - name: "find"
+        in: "query"
+        description: "Finding particular text on subsequent pages in case of table\
+          \ view with pagination"
+        required: false
+        type: "string"
+      - name: "sourceLogId"
+        in: "query"
+        description: "fetch the record set having that log Id"
+        required: false
+        type: "string"
+      - name: "keywordType"
+        in: "query"
+        description: "Serching the find param value in previous or next in paginated\
+          \ table"
+        required: false
+        type: "string"
+      - name: "token"
+        in: "query"
+        description: "unique number used along with FIND_D. The request can be canceled\
+          \ using this token"
+        required: false
+        type: "string"
+      - name: "unit"
+        in: "query"
+        description: "Aggregate the data with time gap as unit i.e 1MINUTE"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get data for histogram"
+      description: ""
+      operationId: "getHistogramDataPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ServiceGraphBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+  /service/logs/export:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Export the table data in file"
+      description: ""
+      operationId: "exportToTextFileGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "level"
+        in: "query"
+        description: "filter for log level"
+        required: false
+        type: "string"
+      - name: "host_name"
+        in: "query"
+        description: "Host name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "component_name"
+        in: "query"
+        description: "Component name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "file_name"
+        in: "query"
+        description: "File name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "bundle_id"
+        in: "query"
+        description: "filter for host"
+        required: false
+        type: "string"
+      - name: "hostList"
+        in: "query"
+        description: "filter for hosts"
+        required: false
+        type: "string"
+      - name: "find"
+        in: "query"
+        description: "Finding particular text on subsequent pages in case of table\
+          \ view with pagination"
+        required: false
+        type: "string"
+      - name: "sourceLogId"
+        in: "query"
+        description: "fetch the record set having that log Id"
+        required: false
+        type: "string"
+      - name: "keywordType"
+        in: "query"
+        description: "Serching the find param value in previous or next in paginated\
+          \ table"
+        required: false
+        type: "string"
+      - name: "token"
+        in: "query"
+        description: "unique number used along with FIND_D. The request can be canceled\
+          \ using this token"
+        required: false
+        type: "string"
+      - name: "format"
+        in: "query"
+        description: "File Export format, can be 'txt' or 'json'"
+        required: false
+        type: "string"
+      - name: "utcOffset"
+        in: "query"
+        description: "timezone offset"
+        required: false
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Export the table data in file"
+      description: ""
+      operationId: "exportToTextFilePost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ServiceLogExportBodyRequest"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+  /service/logs/hosts/components:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get host list of components"
+      description: ""
+      operationId: "getHostListByComponentGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "level"
+        in: "query"
+        description: "filter for log level"
+        required: false
+        type: "string"
+      - name: "host_name"
+        in: "query"
+        description: "Host name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "component_name"
+        in: "query"
+        description: "Component name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "file_name"
+        in: "query"
+        description: "File name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "bundle_id"
+        in: "query"
+        description: "filter for host"
+        required: false
+        type: "string"
+      - name: "hostList"
+        in: "query"
+        description: "filter for hosts"
+        required: false
+        type: "string"
+      - name: "find"
+        in: "query"
+        description: "Finding particular text on subsequent pages in case of table\
+          \ view with pagination"
+        required: false
+        type: "string"
+      - name: "sourceLogId"
+        in: "query"
+        description: "fetch the record set having that log Id"
+        required: false
+        type: "string"
+      - name: "keywordType"
+        in: "query"
+        description: "Serching the find param value in previous or next in paginated\
+          \ table"
+        required: false
+        type: "string"
+      - name: "token"
+        in: "query"
+        description: "unique number used along with FIND_D. The request can be canceled\
+          \ using this token"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/NodeListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get host list of components"
+      description: ""
+      operationId: "getHostListByComponentPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ServiceLogComponentHostBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/NodeListResponse"
+      security:
+      - basicAuth: []
+  /service/logs/components/levels/counts:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get components with log level distribution count"
+      description: ""
+      operationId: "getComponentListWithLevelCountsGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "level"
+        in: "query"
+        description: "filter for log level"
+        required: false
+        type: "string"
+      - name: "host_name"
+        in: "query"
+        description: "Host name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "component_name"
+        in: "query"
+        description: "Component name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "file_name"
+        in: "query"
+        description: "File name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "bundle_id"
+        in: "query"
+        description: "filter for host"
+        required: false
+        type: "string"
+      - name: "hostList"
+        in: "query"
+        description: "filter for hosts"
+        required: false
+        type: "string"
+      - name: "find"
+        in: "query"
+        description: "Finding particular text on subsequent pages in case of table\
+          \ view with pagination"
+        required: false
+        type: "string"
+      - name: "sourceLogId"
+        in: "query"
+        description: "fetch the record set having that log Id"
+        required: false
+        type: "string"
+      - name: "keywordType"
+        in: "query"
+        description: "Serching the find param value in previous or next in paginated\
+          \ table"
+        required: false
+        type: "string"
+      - name: "token"
+        in: "query"
+        description: "unique number used along with FIND_D. The request can be canceled\
+          \ using this token"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/NodeListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get components with log level distribution count"
+      description: ""
+      operationId: "getComponentListWithLevelCountsPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ServiceLogComponentLevelBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/NodeListResponse"
+      security:
+      - basicAuth: []
+  /service/logs/schema/fields:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get service logs schema fields"
+      description: ""
+      operationId: "getServiceLogsSchemaFieldsNameGet"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldMetadata"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get service logs schema fields"
+      description: ""
+      operationId: "getServiceLogsSchemaFieldsNamePost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldMetadata"
+      security:
+      - basicAuth: []
+  /service/logs/count/anygraph:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get the data generic enough to use for graph plots (yAzis is always\
+        \ count)"
+      description: ""
+      operationId: "getAnyGraphCountDataGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "level"
+        in: "query"
+        description: "filter for log level"
+        required: false
+        type: "string"
+      - name: "host_name"
+        in: "query"
+        description: "Host name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "component_name"
+        in: "query"
+        description: "Component name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "file_name"
+        in: "query"
+        description: "File name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "bundle_id"
+        in: "query"
+        description: "filter for host"
+        required: false
+        type: "string"
+      - name: "hostList"
+        in: "query"
+        description: "filter for hosts"
+        required: false
+        type: "string"
+      - name: "find"
+        in: "query"
+        description: "Finding particular text on subsequent pages in case of table\
+          \ view with pagination"
+        required: false
+        type: "string"
+      - name: "sourceLogId"
+        in: "query"
+        description: "fetch the record set having that log Id"
+        required: false
+        type: "string"
+      - name: "keywordType"
+        in: "query"
+        description: "Serching the find param value in previous or next in paginated\
+          \ table"
+        required: false
+        type: "string"
+      - name: "token"
+        in: "query"
+        description: "unique number used along with FIND_D. The request can be canceled\
+          \ using this token"
+        required: false
+        type: "string"
+      - name: "xAxis"
+        in: "query"
+        description: "The column which can be value for x-axis in graph formation"
+        required: false
+        type: "string"
+      - name: "yAxis"
+        in: "query"
+        description: "The column which can be value for y-axis in graph formation"
+        required: false
+        type: "string"
+      - name: "stackBy"
+        in: "query"
+        description: "The graph property for stacking the plot"
+        required: false
+        type: "string"
+      - name: "unit"
+        in: "query"
+        description: "Aggregate the data with time gap as unit i.e 1MINUTE"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get the data generic enough to use for graph plots (yAzis is always\
+        \ count)"
+      description: ""
+      operationId: "getAnyGraphCountDataPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ServiceAnyGraphBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/BarGraphDataListResponse"
+      security:
+      - basicAuth: []
+  /service/logs/truncated:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Preview feature data"
+      description: ""
+      operationId: "getAfterBeforeLogs"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "startIndex"
+        in: "query"
+        description: "Start index of the queried result"
+        required: false
+        type: "string"
+      - name: "page"
+        in: "query"
+        description: "Number of pages for the results"
+        required: false
+        type: "string"
+        default: "0"
+      - name: "pageSize"
+        in: "query"
+        description: "Page size of the results"
+        required: false
+        type: "string"
+        default: "1000"
+      - name: "sortBy"
+        in: "query"
+        description: "Sorting the results based on this field"
+        required: false
+        type: "string"
+      - name: "sortType"
+        in: "query"
+        description: "Type of sorting (osc, desc)"
+        required: false
+        type: "string"
+      - name: "start_time"
+        in: "query"
+        description: "Date range param which is suportted from browser url"
+        required: false
+        type: "string"
+      - name: "end_time"
+        in: "query"
+        description: "Date range param which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      - name: "includeMessage"
+        in: "query"
+        description: "Include query which will query against message column"
+        required: false
+        type: "string"
+      - name: "excludeMessage"
+        in: "query"
+        description: "Exclude query which will query against message column"
+        required: false
+        type: "string"
+      - name: "mustBe"
+        in: "query"
+        description: "Include the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "mustNot"
+        in: "query"
+        description: "Exclude the components, comma separated values"
+        required: false
+        type: "string"
+      - name: "includeQuery"
+        in: "query"
+        description: "Include the values in query result e.g.: [{message:*exception*}]"
+        required: false
+        type: "string"
+      - name: "excludeQuery"
+        in: "query"
+        description: "Exclude the values in query result e.g.: [{message:*timeout*}]"
+        required: false
+        type: "string"
+      - name: "from"
+        in: "query"
+        description: "Date range param, start date"
+        required: false
+        type: "string"
+      - name: "to"
+        in: "query"
+        description: "Date range param, end date"
+        required: false
+        type: "string"
+      - name: "level"
+        in: "query"
+        description: "filter for log level"
+        required: false
+        type: "string"
+      - name: "host_name"
+        in: "query"
+        description: "Host name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "component_name"
+        in: "query"
+        description: "Component name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "file_name"
+        in: "query"
+        description: "File name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "bundle_id"
+        in: "query"
+        description: "filter for host"
+        required: false
+        type: "string"
+      - name: "hostList"
+        in: "query"
+        description: "filter for hosts"
+        required: false
+        type: "string"
+      - name: "find"
+        in: "query"
+        description: "Finding particular text on subsequent pages in case of table\
+          \ view with pagination"
+        required: false
+        type: "string"
+      - name: "sourceLogId"
+        in: "query"
+        description: "fetch the record set having that log Id"
+        required: false
+        type: "string"
+      - name: "keywordType"
+        in: "query"
+        description: "Serching the find param value in previous or next in paginated\
+          \ table"
+        required: false
+        type: "string"
+      - name: "token"
+        in: "query"
+        description: "unique number used along with FIND_D. The request can be canceled\
+          \ using this token"
+        required: false
+        type: "string"
+      - name: "id"
+        in: "query"
+        description: "Log id value for traversing to that particular record with that\
+          \ log id"
+        required: false
+        type: "string"
+      - name: "scrollType"
+        in: "query"
+        description: "Used in 'Preview' feature for getting records 'after' or 'before'"
+        required: false
+        type: "string"
+      - name: "numberRows"
+        in: "query"
+        description: "Getting rows after particular log entry - used in 'Preview'\
+          \ option"
+        required: false
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ServiceLogResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Preview feature data"
+      description: ""
+      operationId: "getAfterBeforeLogs"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ServiceLogTruncatedBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ServiceLogResponse"
+      security:
+      - basicAuth: []
+  /service/logs/request/cancel:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Cancel an ongoing solr request"
+      description: ""
+      operationId: "cancelRequestGet"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Cancel an ongoing solr request"
+      description: ""
+      operationId: "cancelRequestPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+      security:
+      - basicAuth: []
+  /service/logs/files:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get the log files of the components of a host"
+      description: ""
+      operationId: "getHostLogFiles"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "host_name"
+        in: "query"
+        description: "Host name filter which is supported from browser url"
+        required: true
+        type: "string"
+      - name: "component_name"
+        in: "query"
+        description: "Component name filter which is supported from browser url"
+        required: false
+        type: "string"
+      - name: "clusters"
+        in: "query"
+        description: "filter for clusters (comma separated list)"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/HostLogFilesResponse"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get the log files of the components of a host"
+      description: ""
+      operationId: "getHostLogFiles"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/HostLogFilesBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/HostLogFilesResponse"
+      security:
+      - basicAuth: []
+  /service/logs/clusters:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get all of the clusters for service logs"
+      description: ""
+      operationId: "getClustersForServiceLogGet"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get all of the clusters for service logs"
+      description: ""
+      operationId: "getClustersForServiceLogPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+      security:
+      - basicAuth: []
+  /shipper/filters/{clusterName}/level:
+    get:
+      tags:
+      - "shipper"
+      summary: "Get log level filter"
+      description: ""
+      operationId: "getLogLevelFilters"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusterName"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/LSServerLogLevelFilterMap"
+      security:
+      - basicAuth: []
+    put:
+      tags:
+      - "shipper"
+      summary: "Update log level filter"
+      description: ""
+      operationId: "setLogLevelFilter"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/LSServerLogLevelFilterMap"
+      - name: "clusterName"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+  /shipper/input/{clusterName}/services:
+    get:
+      tags:
+      - "shipper"
+      summary: "Get service names"
+      description: ""
+      operationId: "getServices"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusterName"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+      security:
+      - basicAuth: []
+  /shipper/input/{clusterName}/services/{serviceName}:
+    get:
+      tags:
+      - "shipper"
+      summary: "Get shipper config"
+      description: ""
+      operationId: "getShipperConfig"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusterName"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "serviceName"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/LSServerInputConfig"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "shipper"
+      summary: "Set shipper config"
+      description: ""
+      operationId: "createShipperConfig"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/LSServerInputConfig"
+      - name: "clusterName"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "serviceName"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+    put:
+      tags:
+      - "shipper"
+      summary: "Set shipper config"
+      description: ""
+      operationId: "setShipperConfig"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/LSServerInputConfig"
+      - name: "clusterName"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "serviceName"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+  /shipper/input/{clusterName}/test:
+    post:
+      tags:
+      - "shipper"
+      summary: "Test shipper config"
+      description: ""
+      operationId: "testShipperConfig"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "logId"
+        in: "formData"
+        description: "Id of the log component"
+        required: true
+        type: "string"
+      - name: "testEntry"
+        in: "formData"
+        description: "Log sample for testing"
+        required: true
+        type: "string"
+      - name: "shipperConfig"
+        in: "formData"
+        description: "Input config json for logfeeder shipper"
+        required: true
+        type: "string"
+      - name: "clusterName"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+  /status:
+    get:
+      tags:
+      - "status"
+      summary: "Get statuses for collections (not health state - show true if something\
+        \ already done)"
+      description: ""
+      operationId: "getStatus"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              $ref: "#/definitions/SolrCollectionState"
+      security:
+      - basicAuth: []
+  /status/servicelogs:
+    get:
+      tags:
+      - "status"
+      summary: "Get statuses for service log collection (not health state - show true\
+        \ if something already done)"
+      description: ""
+      operationId: "getServiceLogStatus"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/SolrCollectionState"
+      security:
+      - basicAuth: []
+  /status/auditlogs:
+    get:
+      tags:
+      - "status"
+      summary: "Get statuses for collections (not health state - show true if something\
+        \ already done)"
+      description: ""
+      operationId: "getSolrAuditLogsStatus"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/SolrCollectionState"
+      security:
+      - basicAuth: []
+  /status/metadata:
+    get:
+      tags:
+      - "status"
+      summary: "Get statuses for metadata collection (not health state - show true\
+        \ if something already done)"
+      description: ""
+      operationId: "getSolrEventHistoryStatus"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/SolrCollectionState"
+      security:
+      - basicAuth: []
+securityDefinitions:
+  basicAuth:
+    type: "basic"
+definitions:
+  AuditFieldMetadataResponse:
+    type: "object"
+    properties:
+      defaults:
+        type: "array"
+        items:
+          $ref: "#/definitions/FieldMetadata"
+      overrides:
+        type: "object"
+        additionalProperties:
+          type: "array"
+          items:
+            $ref: "#/definitions/FieldMetadata"
+  FieldMetadata:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      label:
+        type: "string"
+      filterable:
+        type: "boolean"
+      visible:
+        type: "boolean"
+  AuditLogData:
+    type: "object"
+    properties:
+      resource:
+        type: "string"
+      result:
+        type: "integer"
+        format: "int32"
+      text:
+        type: "string"
+      access:
+        type: "string"
+      reqContext:
+        type: "string"
+      policy:
+        type: "string"
+      sess:
+        type: "string"
+      proxyUsers:
+        type: "array"
+        items:
+          type: "string"
+      agent:
+        type: "string"
+      repo:
+        type: "string"
+      tags:
+        type: "array"
+        items:
+          type: "string"
+      agentHost:
+        type: "string"
+      cliIP:
+        type: "string"
+      cliType:
+        type: "string"
+      enforcer:
+        type: "string"
+      evtTime:
+        type: "string"
+        format: "date-time"
+      reason:
+        type: "string"
+      repoType:
+        type: "integer"
+        format: "int32"
+      reqData:
+        type: "string"
+      reqUser:
+        type: "string"
+      resType:
+        type: "string"
+      tags_str:
+        type: "string"
+      action:
+        type: "string"
+      logType:
+        type: "string"
+      id:
+        type: "string"
+      type:
+        type: "string"
+      file:
+        type: "string"
+      _version_:
+        type: "integer"
+        format: "int64"
+      log_message:
+        type: "string"
+      _ttl_:
+        type: "string"
+      _expire_at_:
+        type: "string"
+        format: "date-time"
+      _router_field_:
+        type: "integer"
+        format: "int32"
+      bundle_id:
+        type: "string"
+      seq_num:
+        type: "integer"
+        format: "int64"
+      message_md5:
+        type: "string"
+      cluster:
+        type: "string"
+      event_count:
+        type: "integer"
+        format: "int64"
+      event_md5:
+        type: "string"
+      event_dur_ms:
+        type: "integer"
+        format: "int64"
+      case_id:
+        type: "string"
+      logfile_line_number:
+        type: "integer"
+        format: "int32"
+  AuditLogResponse:
+    type: "object"
+    properties:
+      startIndex:
+        type: "integer"
+        format: "int32"
+      pageSize:
+        type: "integer"
+        format: "int32"
+      totalCount:
+        type: "integer"
+        format: "int64"
+      resultSize:
+        type: "integer"
+        format: "int32"
+      sortType:
+        type: "string"
+      sortBy:
+        type: "string"
+      queryTimeMS:
+        type: "integer"
+        format: "int64"
+      logList:
+        type: "array"
+        items:
+          $ref: "#/definitions/AuditLogData"
+      listSize:
+        type: "integer"
+        format: "int32"
+  AuditLogBodyRequest:
+    type: "object"
+    properties:
+      lastPage:
+        type: "boolean"
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      userList:
+        type: "string"
+  StatusMessage:
+    type: "object"
+    properties:
+      status:
+        type: "integer"
+        format: "int32"
+      message:
+        type: "string"
+      statusCode:
+        type: "integer"
+        format: "int32"
+  ClusterBodyRequest:
+    type: "object"
+    properties:
+      clusters:
+        type: "string"
+  BarGraphData:
+    type: "object"
+    properties:
+      dataCount:
+        type: "array"
+        items:
+          $ref: "#/definitions/NameValueData"
+      name:
+        type: "string"
+  BarGraphDataListResponse:
+    type: "object"
+    properties:
+      graphData:
+        type: "array"
+        items:
+          $ref: "#/definitions/BarGraphData"
+  NameValueData:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      value:
+        type: "string"
+  AuditBarGraphBodyRequest:
+    type: "object"
+    properties:
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      userList:
+        type: "string"
+      unit:
+        type: "string"
+  TopFieldAuditLogBodyRequest:
+    type: "object"
+    properties:
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      field:
+        type: "string"
+      userList:
+        type: "string"
+  UserExportBodyRequest:
+    type: "object"
+    properties:
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      field:
+        type: "string"
+      userList:
+        type: "string"
+      format:
+        type: "string"
+  AuditServiceLoadBodyRequest:
+    type: "object"
+    properties:
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      userList:
+        type: "string"
+  LogsearchMetaData:
+    type: "object"
+    properties:
+      id:
+        type: "string"
+      userName:
+        type: "string"
+      name:
+        type: "string"
+      value:
+        type: "string"
+      type:
+        type: "string"
+  ComponentMetadata:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      label:
+        type: "string"
+      group:
+        type: "string"
+  ServiceComponentMetadataWrapper:
+    type: "object"
+    properties:
+      groups:
+        type: "object"
+        additionalProperties:
+          type: "string"
+      metadata:
+        type: "array"
+        items:
+          $ref: "#/definitions/ComponentMetadata"
+  ServiceLogData:
+    type: "object"
+    properties:
+      method:
+        type: "string"
+      type:
+        type: "string"
+      path:
+        type: "string"
+      host:
+        type: "string"
+      line_number:
+        type: "integer"
+        format: "int32"
+      group:
+        type: "string"
+      level:
+        type: "string"
+      logger_name:
+        type: "string"
+      logtime:
+        type: "string"
+        format: "date-time"
+      ip:
+        type: "string"
+      id:
+        type: "string"
+      file:
+        type: "string"
+      _version_:
+        type: "integer"
+        format: "int64"
+      log_message:
+        type: "string"
+      _ttl_:
+        type: "string"
+      _expire_at_:
+        type: "string"
+        format: "date-time"
+      _router_field_:
+        type: "integer"
+        format: "int32"
+      bundle_id:
+        type: "string"
+      seq_num:
+        type: "integer"
+        format: "int64"
+      message_md5:
+        type: "string"
+      cluster:
+        type: "string"
+      event_count:
+        type: "integer"
+        format: "int64"
+      event_md5:
+        type: "string"
+      event_dur_ms:
+        type: "integer"
+        format: "int64"
+      case_id:
+        type: "string"
+      logfile_line_number:
+        type: "integer"
+        format: "int32"
+  ServiceLogResponse:
+    type: "object"
+    properties:
+      startIndex:
+        type: "integer"
+        format: "int32"
+      pageSize:
+        type: "integer"
+        format: "int32"
+      totalCount:
+        type: "integer"
+        format: "int64"
+      resultSize:
+        type: "integer"
+        format: "int32"
+      sortType:
+        type: "string"
+      sortBy:
+        type: "string"
+      queryTimeMS:
+        type: "integer"
+        format: "int64"
+      logList:
+        type: "array"
+        items:
+          $ref: "#/definitions/ServiceLogData"
+      listSize:
+        type: "integer"
+        format: "int32"
+  ServiceLogBodyRequest:
+    type: "object"
+    properties:
+      lastPage:
+        type: "boolean"
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      level:
+        type: "string"
+      host_name:
+        type: "string"
+      component_name:
+        type: "string"
+      file_name:
+        type: "string"
+      bundle_id:
+        type: "string"
+      hostList:
+        type: "string"
+      find:
+        type: "string"
+      sourceLogId:
+        type: "string"
+      keywordType:
+        type: "string"
+      token:
+        type: "string"
+  GroupListResponse:
+    type: "object"
+    properties:
+      startIndex:
+        type: "integer"
+        format: "int32"
+      pageSize:
+        type: "integer"
+        format: "int32"
+      totalCount:
+        type: "integer"
+        format: "int64"
+      resultSize:
+        type: "integer"
+        format: "int32"
+      sortType:
+        type: "string"
+      sortBy:
+        type: "string"
+      queryTimeMS:
+        type: "integer"
+        format: "int64"
+      groupList:
+        type: "array"
+        items:
+          $ref: "#/definitions/LogData"
+      listSize:
+        type: "integer"
+        format: "int32"
+  LogData:
+    type: "object"
+  GraphData:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      count:
+        type: "integer"
+        format: "int64"
+      dataList:
+        type: "array"
+        items:
+          $ref: "#/definitions/GraphData"
+  GraphDataListResponse:
+    type: "object"
+    properties:
+      graphData:
+        type: "array"
+        items:
+          $ref: "#/definitions/GraphData"
+  ServiceLogAggregatedInfoBodyRequest:
+    type: "object"
+    properties:
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      level:
+        type: "string"
+      host_name:
+        type: "string"
+      component_name:
+        type: "string"
+      file_name:
+        type: "string"
+      bundle_id:
+        type: "string"
+      hostList:
+        type: "string"
+  CountData:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      count:
+        type: "integer"
+        format: "int64"
+  CountDataListResponse:
+    type: "object"
+    properties:
+      startIndex:
+        type: "integer"
+        format: "int32"
+      pageSize:
+        type: "integer"
+        format: "int32"
+      totalCount:
+        type: "integer"
+        format: "int64"
+      resultSize:
+        type: "integer"
+        format: "int32"
+      sortType:
+        type: "string"
+      sortBy:
+        type: "string"
+      queryTimeMS:
+        type: "integer"
+        format: "int64"
+      getvCounts:
+        type: "array"
+        items:
+          $ref: "#/definitions/CountData"
+      listSize:
+        type: "integer"
+        format: "int32"
+  NodeData:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      type:
+        type: "string"
+      value:
+        type: "string"
+      childs:
+        type: "array"
+        items:
+          $ref: "#/definitions/NodeData"
+      logLevelCount:
+        type: "array"
+        items:
+          $ref: "#/definitions/NameValueData"
+      isParent:
+        type: "boolean"
+      isRoot:
+        type: "boolean"
+  NodeListResponse:
+    type: "object"
+    properties:
+      startIndex:
+        type: "integer"
+        format: "int32"
+      pageSize:
+        type: "integer"
+        format: "int32"
+      totalCount:
+        type: "integer"
+        format: "int64"
+      resultSize:
+        type: "integer"
+        format: "int32"
+      sortType:
+        type: "string"
+      sortBy:
+        type: "string"
+      queryTimeMS:
+        type: "integer"
+        format: "int64"
+      getvNodeList:
+        type: "array"
+        items:
+          $ref: "#/definitions/NodeData"
+      listSize:
+        type: "integer"
+        format: "int32"
+  ServiceLogHostComponentBodyRequest:
+    type: "object"
+    properties:
+      lastPage:
+        type: "boolean"
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      level:
+        type: "string"
+      hostName:
+        type: "string"
+      component_name:
+        type: "string"
+      file_name:
+        type: "string"
+      bundle_id:
+        type: "string"
+      hostList:
+        type: "string"
+      find:
+        type: "string"
+      sourceLogId:
+        type: "string"
+      keywordType:
+        type: "string"
+      token:
+        type: "string"
+  NameValueDataListResponse:
+    type: "object"
+    properties:
+      startIndex:
+        type: "integer"
+        format: "int32"
+      pageSize:
+        type: "integer"
+        format: "int32"
+      totalCount:
+        type: "integer"
+        format: "int64"
+      resultSize:
+        type: "integer"
+        format: "int32"
+      sortType:
+        type: "string"
+      sortBy:
+        type: "string"
+      queryTimeMS:
+        type: "integer"
+        format: "int64"
+      getvNameValues:
+        type: "array"
+        items:
+          $ref: "#/definitions/NameValueData"
+      listSize:
+        type: "integer"
+        format: "int32"
+  ServiceLogLevelCountBodyRequest:
+    type: "object"
+    properties:
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      level:
+        type: "string"
+      host_name:
+        type: "string"
+      component_name:
+        type: "string"
+      file_name:
+        type: "string"
+      bundle_id:
+        type: "string"
+      hostList:
+        type: "string"
+  ServiceGraphBodyRequest:
+    type: "object"
+    properties:
+      lastPage:
+        type: "boolean"
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      level:
+        type: "string"
+      host_name:
+        type: "string"
+      component_name:
+        type: "string"
+      file_name:
+        type: "string"
+      bundle_id:
+        type: "string"
+      hostList:
+        type: "string"
+      find:
+        type: "string"
+      sourceLogId:
+        type: "string"
+      keywordType:
+        type: "string"
+      token:
+        type: "string"
+      unit:
+        type: "string"
+  ServiceLogExportBodyRequest:
+    type: "object"
+    properties:
+      lastPage:
+        type: "boolean"
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      level:
+        type: "string"
+      host_name:
+        type: "string"
+      component_name:
+        type: "string"
+      file_name:
+        type: "string"
+      bundle_id:
+        type: "string"
+      hostList:
+        type: "string"
+      find:
+        type: "string"
+      sourceLogId:
+        type: "string"
+      keywordType:
+        type: "string"
+      token:
+        type: "string"
+      format:
+        type: "string"
+      utcOffset:
+        type: "string"
+  ServiceLogComponentHostBodyRequest:
+    type: "object"
+    properties:
+      lastPage:
+        type: "boolean"
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      level:
+        type: "string"
+      host_name:
+        type: "string"
+      component_name:
+        type: "string"
+      file_name:
+        type: "string"
+      bundle_id:
+        type: "string"
+      hostList:
+        type: "string"
+      find:
+        type: "string"
+      sourceLogId:
+        type: "string"
+      keywordType:
+        type: "string"
+      token:
+        type: "string"
+  ServiceLogComponentLevelBodyRequest:
+    type: "object"
+    properties:
+      lastPage:
+        type: "boolean"
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      level:
+        type: "string"
+      host_name:
+        type: "string"
+      component_name:
+        type: "string"
+      file_name:
+        type: "string"
+      bundle_id:
+        type: "string"
+      hostList:
+        type: "string"
+      find:
+        type: "string"
+      sourceLogId:
+        type: "string"
+      keywordType:
+        type: "string"
+      token:
+        type: "string"
+  ServiceAnyGraphBodyRequest:
+    type: "object"
+    properties:
+      lastPage:
+        type: "boolean"
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      level:
+        type: "string"
+      host_name:
+        type: "string"
+      component_name:
+        type: "string"
+      file_name:
+        type: "string"
+      bundle_id:
+        type: "string"
+      hostList:
+        type: "string"
+      find:
+        type: "string"
+      sourceLogId:
+        type: "string"
+      keywordType:
+        type: "string"
+      token:
+        type: "string"
+      getxAxis:
+        type: "string"
+      getyAxis:
+        type: "string"
+      stackBy:
+        type: "string"
+      unit:
+        type: "string"
+  ServiceLogTruncatedBodyRequest:
+    type: "object"
+    properties:
+      lastPage:
+        type: "boolean"
+      startIndex:
+        type: "string"
+      page:
+        type: "string"
+      pageSize:
+        type: "string"
+      sortBy:
+        type: "string"
+      sortType:
+        type: "string"
+      start_time:
+        type: "string"
+      end_time:
+        type: "string"
+      clusters:
+        type: "string"
+      includeMessage:
+        type: "string"
+      excludeMessage:
+        type: "string"
+      mustBe:
+        type: "string"
+      mustNot:
+        type: "string"
+      includeQuery:
+        type: "string"
+      excludeQuery:
+        type: "string"
+      from:
+        type: "string"
+      to:
+        type: "string"
+      level:
+        type: "string"
+      host_name:
+        type: "string"
+      component_name:
+        type: "string"
+      file_name:
+        type: "string"
+      bundle_id:
+        type: "string"
+      hostList:
+        type: "string"
+      find:
+        type: "string"
+      sourceLogId:
+        type: "string"
+      keywordType:
+        type: "string"
+      token:
+        type: "string"
+      id:
+        type: "string"
+      scrollType:
+        type: "string"
+      numberRows:
+        type: "integer"
+        format: "int32"
+  HostLogFilesResponse:
+    type: "object"
+    properties:
+      hostLogFiles:
+        type: "object"
+        additionalProperties:
+          type: "array"
+          items:
+            type: "string"
+  HostLogFilesBodyRequest:
+    type: "object"
+    required:
+    - "host_name"
+    properties:
+      host_name:
+        type: "string"
+      component_name:
+        type: "string"
+      clusters:
+        type: "string"
+  LSServerLogLevelFilter:
+    type: "object"
+    required:
+    - "defaultLevels"
+    - "hosts"
+    - "label"
+    properties:
+      label:
+        type: "string"
+      hosts:
+        type: "array"
+        items:
+          type: "string"
+      defaultLevels:
+        type: "array"
+        items:
+          type: "string"
+      overrideLevels:
+        type: "array"
+        items:
+          type: "string"
+      expiryTime:
+        type: "string"
+        format: "date-time"
+  LSServerLogLevelFilterMap:
+    type: "object"
+    required:
+    - "filter"
+    properties:
+      filter:
+        type: "object"
+        additionalProperties:
+          $ref: "#/definitions/LSServerLogLevelFilter"
+  LSServerConditions:
+    type: "object"
+    required:
+    - "fields"
+    properties:
+      fields:
+        $ref: "#/definitions/LSServerFields"
+  LSServerFields:
+    type: "object"
+    required:
+    - "type"
+    properties:
+      type:
+        type: "array"
+        uniqueItems: true
+        items:
+          type: "string"
+  LSServerFilter:
+    type: "object"
+    required:
+    - "conditions"
+    - "filter"
+    properties:
+      filter:
+        type: "string"
+      conditions:
+        $ref: "#/definitions/LSServerConditions"
+      sort_order:
+        type: "integer"
+        format: "int32"
+      source_field:
+        type: "string"
+      remove_source_field:
+        type: "boolean"
+      post_map_values:
+        type: "object"
+        additionalProperties:
+          $ref: "#/definitions/LSServerPostMapValuesList"
+      is_enabled:
+        type: "boolean"
+  LSServerInput:
+    type: "object"
+    required:
+    - "path"
+    - "type"
+    properties:
+      type:
+        type: "string"
+      rowtype:
+        type: "string"
+      path:
+        type: "string"
+      source:
+        type: "string"
+      tail:
+        type: "boolean"
+      add_fields:
+        type: "object"
+        readOnly: true
+        additionalProperties:
+          type: "string"
+      gen_event_md5:
+        type: "boolean"
+        readOnly: true
+      use_event_md5_as_id:
+        type: "boolean"
+        readOnly: true
+      cache_enabled:
+        type: "boolean"
+        readOnly: true
+      cache_key_field:
+        type: "string"
+        readOnly: true
+      cache_last_dedup_enabled:
+        type: "boolean"
+        readOnly: true
+      cache_size:
+        type: "integer"
+        format: "int32"
+        readOnly: true
+      cache_dedup_interval:
+        type: "integer"
+        format: "int64"
+        readOnly: true
+      is_enabled:
+        type: "boolean"
+        readOnly: true
+      init_default_fields:
+        type: "boolean"
+        readOnly: true
+      default_log_levels:
+        type: "array"
+        readOnly: true
+        items:
+          type: "string"
+  LSServerInputConfig:
+    type: "object"
+    required:
+    - "filter"
+    - "input"
+    properties:
+      input:
+        type: "array"
+        items:
+          $ref: "#/definitions/LSServerInput"
+      filter:
+        type: "array"
+        items:
+          $ref: "#/definitions/LSServerFilter"
+  LSServerPostMapValuesList:
+    type: "object"
+  SolrCollectionState:
+    type: "object"
+    properties:
+      znodeReady:
+        type: "boolean"
+      solrCollectionReady:
+        type: "boolean"
+      configurationUploaded:
+        type: "boolean"

--- a/docs/cloud_mode.md
+++ b/docs/cloud_mode.md
@@ -1,0 +1,16 @@
+<!---
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,0 +1,16 @@
+<!---
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,22 @@
+<!---
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+## Installation
+
+## Build
+
+## Requirements

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+<!---
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+## Introduction
+
+Log aggregation, analysis, and visualization for Ambari managed (or any other) services.
+
+## Architecture

--- a/docs/logfeeder_properties.md
+++ b/docs/logfeeder_properties.md
@@ -1,0 +1,104 @@
+<!---
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+## Log Feeder Configurations
+
+| `Name` | `Description` | `Default` | `Examples` |
+|---|---|---|---|
+|`cluster.name`|The name of the cluster the Log Feeder program runs in.|`EMPTY`|<ul><li>`cl1`</li></ul>|
+|`hadoop.security.credential.provider.path`|The jceks file that provides passwords.|`EMPTY`|<ul><li>`jceks://file/etc/ambari-logsearch-logfeeder/conf/logfeeder.jceks`</li></ul>|
+|`logfeeder.cache.dedup.interval`|Maximum number of milliseconds between two identical messages to be filtered out.|1000|<ul><li>`500`</li></ul>|
+|`logfeeder.cache.enabled`|Enables the usage of a cache to avoid duplications.|false|<ul><li>`true`</li></ul>|
+|`logfeeder.cache.key.field`|The field which's value should be cached and should be checked for repetitions.|log_message|<ul><li>`some_field_prone_to_repeating_value`</li></ul>|
+|`logfeeder.cache.last.dedup.enabled`|Enable filtering directly repeating log entries irrelevant of the time spent between them.|false|<ul><li>`true`</li></ul>|
+|`logfeeder.cache.size`|The number of log entries to cache in order to avoid duplications.|100|<ul><li>`50`</li></ul>|
+|`logfeeder.checkpoint.extension`|The extension used for checkpoint files.|.cp|<ul><li>`ckp`</li></ul>|
+|`logfeeder.checkpoint.folder`|The folder where checkpoint files are stored.|`EMPTY`|<ul><li>`/usr/lib/ambari-logsearch-logfeeder/conf/checkpoints`</li></ul>|
+|`logfeeder.cloud.rollover.archive.base.dir`|Location where the active and archives logs will be stored. Beware, it could require a large amount of space, use mounted disks if it is possible.|/tmp|<ul><li>`/var/lib/ambari-logsearch-logfeeder/data`</li></ul>|
+|`logfeeder.cloud.rollover.immediate.flush`|Immediately flush temporal cloud logs (to active location).|true|<ul><li>`false`</li></ul>|
+|`logfeeder.cloud.rollover.max.files`|The number of max backup log files for rolled over logs.|10|<ul><li>`50`</li></ul>|
+|`logfeeder.cloud.rollover.on.shutdown`|Rollover temporal cloud log files on shutdown|true|<ul><li>`false`</li></ul>|
+|`logfeeder.cloud.rollover.on.startup`|Rollover temporal cloud log files on startup|true|<ul><li>`false`</li></ul>|
+|`logfeeder.cloud.rollover.threshold.min`|Rollover cloud log files after an interval (minutes)|60|<ul><li>`1`</li></ul>|
+|`logfeeder.cloud.rollover.threshold.size`|Rollover cloud log files after the log file size reach this limit|80|<ul><li>`1024`</li></ul>|
+|`logfeeder.cloud.rollover.threshold.size.unit`|Rollover cloud log file size unit (e.g: KB, MB etc.)|MB|<ul><li>`KB`</li></ul>|
+|`logfeeder.cloud.rollover.use.gzip`|Use GZip on archived logs.|true|<ul><li>`false`</li></ul>|
+|`logfeeder.cloud.storage.base.path`|Base path prefix for storing logs (cloud storage / hdfs)|/apps/logsearch|<ul><li>`/user/logsearch/mypath`</li></ul>|
+|`logfeeder.cloud.storage.bucket`|Amazon S3 bucket.|logfeeder|<ul><li>`logs`</li></ul>|
+|`logfeeder.cloud.storage.bucket.bootstrap`|Create bucket on startup.|true|<ul><li>`false`</li></ul>|
+|`logfeeder.cloud.storage.custom.fs`|If it is not empty, override fs.defaultFS for HDFS client. Can be useful to write data to a different bucket (from other services) if the bucket address is read from core-site.xml|`EMPTY`|<ul><li>`s3a://anotherbucket`</li></ul>|
+|`logfeeder.cloud.storage.destination`|Type of storage that is the destination for cloud output logs.|none|<ul><li>`hdfs`</li><li>`s3`</li></ul>|
+|`logfeeder.cloud.storage.mode`|Option to support sending logs to cloud storage. You can choose between supporting only cloud storage, non-cloud storage or both|default|<ul><li>`default`</li><li>`cloud`</li><li>`hybrid`</li></ul>|
+|`logfeeder.cloud.storage.upload.on.shutdown`|Try to upload archived files on shutdown|false|<ul><li>`true`</li></ul>|
+|`logfeeder.cloud.storage.uploader.interval.seconds`|Second interval, that is used to check against there are any files to upload to cloud storage or not.|60|<ul><li>`10`</li></ul>|
+|`logfeeder.cloud.storage.uploader.timeout.minutes`|Timeout value for uploading task to cloud storage in minutes.|60|<ul><li>`10`</li></ul>|
+|`logfeeder.cloud.storage.use.filters`|Use filters for inputs (with filters the output format will be JSON)|false|<ul><li>`true`</li></ul>|
+|`logfeeder.cloud.storage.use.hdfs.client`|Use hdfs client with cloud connectors instead of the core clients for shipping data to cloud storage|false|<ul><li>`true`</li></ul>|
+|`logfeeder.config.dir`|The directory where shipper configuration files are looked for.|/usr/lib/ambari-logsearch-logfeeder/conf|<ul><li>`/usr/lib/ambari-logsearch-logfeeder/conf`</li></ul>|
+|`logfeeder.config.files`|Comma separated list of the config files containing global / output configurations.|`EMPTY`|<ul><li>`global.json,output.json`</li><li>`/usr/lib/ambari-logsearch-logfeeder/conf/global.config.json`</li></ul>|
+|`logfeeder.configs.filter.solr.enabled`|Use solr as a log level filter storage|false|<ul><li>`true`</li></ul>|
+|`logfeeder.configs.filter.solr.monitor.enabled`|Monitor log level filters (in solr) periodically - used for checking updates.|true|<ul><li>`false`</li></ul>|
+|`logfeeder.configs.filter.solr.monitor.interval`|Time interval (in seconds) between monitoring input config filter definitions from Solr.|30|<ul><li>`60`</li></ul>|
+|`logfeeder.configs.filter.zk.enabled`|Use zk as a log level filter storage (works only with local config)|false|<ul><li>`true`</li></ul>|
+|`logfeeder.configs.local.enabled`|Monitor local input.config-*.json files (do not upload them to zookeeper or solr)|false|<ul><li>`true`</li></ul>|
+|`logfeeder.docker.registry.enabled`|Enable to monitor docker containers and store their metadata in an in-memory registry.|false|<ul><li>`true`</li></ul>|
+|`logfeeder.hdfs.file.permissions`|Default permissions for created files on HDFS|640|<ul><li>`600`</li></ul>|
+|`logfeeder.hdfs.host`|HDFS Name Node host.|`EMPTY`|<ul><li>`mynamenodehost`</li></ul>|
+|`logfeeder.hdfs.kerberos`|Enable kerberos support for HDFS|false|<ul><li>`true`</li></ul>|
+|`logfeeder.hdfs.keytab`|Kerberos keytab location for Log Feeder for communicating with secure HDFS. |/etc/security/keytabs/logfeeder.service.keytab|<ul><li>`/etc/security/keytabs/mykeytab.keytab`</li></ul>|
+|`logfeeder.hdfs.port`|HDFS Name Node port|`EMPTY`|<ul><li>`9000`</li></ul>|
+|`logfeeder.hdfs.principal`|Kerberos principal for Log Feeder for communicating with secure HDFS. |logfeeder/_HOST|<ul><li>`mylogfeeder/myhost1@EXAMPLE.COM`</li></ul>|
+|`logfeeder.hdfs.user`|Overrides HADOOP_USER_NAME variable at runtime|`EMPTY`|<ul><li>`hdfs`</li></ul>|
+|`logfeeder.include.default.level`|Comma separated list of the default log levels to be enabled by the filtering.|`EMPTY`|<ul><li>`FATAL,ERROR,WARN`</li></ul>|
+|`logfeeder.log.filter.enable`|Enables the filtering of the log entries by log level filters.|false|<ul><li>`true`</li></ul>|
+|`logfeeder.metrics.collector.hosts`|Comma separtaed list of metric collector hosts.|`EMPTY`|<ul><li>`c6401.ambari.apache.org,c6402.ambari.apache.org`</li></ul>|
+|`logfeeder.metrics.collector.path`|The path used by metric collectors.|`EMPTY`|<ul><li>`/ws/v1/timeline/metrics`</li></ul>|
+|`logfeeder.metrics.collector.port`|The port used by metric collectors.|`EMPTY`|<ul><li>`6188`</li></ul>|
+|`logfeeder.metrics.collector.protocol`|The protocol used by metric collectors.|`EMPTY`|<ul><li>`http`</li><li>`https`</li></ul>|
+|`logfeeder.s3.access.key`|Amazon S3 secret access key.|`EMPTY`|<ul><li>`MySecretAccessKey`</li></ul>|
+|`logfeeder.s3.access.key.file`|Amazon S3 secret access key file (that contains only the key).|`EMPTY`|<ul><li>`/my/path/access_key`</li></ul>|
+|`logfeeder.s3.credentials.file.enabled`|Enable to get Amazon S3 secret/access keys from files.|`EMPTY`|<ul><li>`true`</li></ul>|
+|`logfeeder.s3.credentials.hadoop.access.ref`|Amazon S3 access key reference in Hadoop credential store..|logfeeder.s3.access.key|<ul><li>`logfeeder.s3.access.key`</li></ul>|
+|`logfeeder.s3.credentials.hadoop.enabled`|Enable to get Amazon S3 secret/access keys from Hadoop credential store API.|`EMPTY`|<ul><li>`true`</li></ul>|
+|`logfeeder.s3.credentials.hadoop.secret.ref`|Amazon S3 secret access key reference in Hadoop credential store..|logfeeder.s3.secret.key|<ul><li>`logfeeder.s3.secret.key`</li></ul>|
+|`logfeeder.s3.endpoint`|Amazon S3 endpoint.|https://s3.amazonaws.com|<ul><li>`https://s3.amazonaws.com`</li></ul>|
+|`logfeeder.s3.multiobject.delete.enable`|When enabled, multiple single-object delete requests are replaced by a single 'delete multiple objects'-request, reducing the number of requests.|true|<ul><li>`false`</li></ul>|
+|`logfeeder.s3.object.acl`|Amazon S3 ACLs for new objects.|private|<ul><li>`logs`</li></ul>|
+|`logfeeder.s3.path.style.access`|Enable S3 path style access will disable the default virtual hosting behaviour (DNS).|false|<ul><li>`true`</li></ul>|
+|`logfeeder.s3.region`|Amazon S3 region.|`EMPTY`|<ul><li>`us-east-2`</li></ul>|
+|`logfeeder.s3.secret.key`|Amazon S3 secret key.|`EMPTY`|<ul><li>`MySecretKey`</li></ul>|
+|`logfeeder.s3.secret.key.file`|Amazon S3 secret key file (that contains only the key).|`EMPTY`|<ul><li>`/my/path/secret_key`</li></ul>|
+|`logfeeder.simulate.input_number`|The number of the simulator instances to run with. O means no simulation.|0|<ul><li>`10`</li></ul>|
+|`logfeeder.simulate.log_ids`|The comma separated list of log ids for which to create the simulated log entries.|The log ids of the installed services in the cluster|<ul><li>`ambari_server,zookeeper,infra_solr,logsearch_app`</li></ul>|
+|`logfeeder.simulate.log_level`|The log level to create the simulated log entries with.|WARN|<ul><li>`INFO`</li></ul>|
+|`logfeeder.simulate.max_log_words`|The maximum number of words in a simulated log entry.|5|<ul><li>`8`</li></ul>|
+|`logfeeder.simulate.min_log_words`|The minimum number of words in a simulated log entry.|5|<ul><li>`3`</li></ul>|
+|`logfeeder.simulate.number_of_words`|The size of the set of words that may be used to create the simulated log entries with.|1000|<ul><li>`100`</li></ul>|
+|`logfeeder.simulate.sleep_milliseconds`|The milliseconds to sleep between creating two simulated log entries.|10000|<ul><li>`5000`</li></ul>|
+|`logfeeder.solr.cloud.client.discover`|On startup, with a Solr Cloud client, the Solr nodes will be discovered, then LBHttpClient will be built from that.|false|<ul><li>`true`</li></ul>|
+|`logfeeder.solr.implicit.routing`|Use implicit routing for Solr Collections.|false|<ul><li>`true`</li></ul>|
+|`logfeeder.solr.jaas.file`|The jaas file used for solr.|/etc/security/keytabs/logsearch_solr.service.keytab|<ul><li>`/usr/lib/ambari-logsearch-logfeeder/conf/logfeeder_jaas.conf`</li></ul>|
+|`logfeeder.solr.kerberos.enable`|Enables using kerberos for accessing solr.|false|<ul><li>`true`</li></ul>|
+|`logfeeder.solr.metadata.collection`|Metadata collection name that could contain log level filters or input configurations.|`EMPTY`|<ul><li>`logsearch_metadata`</li></ul>|
+|`logfeeder.solr.urls`|Comma separated solr urls (with protocol and port), override logfeeder.solr.zk_connect_string config|`EMPTY`|<ul><li>`https://localhost1:8983/solr,https://localhost2:8983`</li></ul>|
+|`logfeeder.solr.zk_connect_string`|Zookeeper connection string for Solr.|`EMPTY`|<ul><li>`localhost1:2181,localhost2:2181/mysolr_znode`</li></ul>|
+|`logfeeder.tmp.dir`|The tmp dir used for creating temporary files.|java.io.tmpdir|<ul><li>`/tmp/`</li></ul>|
+|`logsearch.config.zk_acls`|ZooKeeper ACLs for handling configs. (read & write)|world:anyone:cdrwa|<ul><li>`world:anyone:r,sasl:solr:cdrwa,sasl:logsearch:cdrwa`</li></ul>|
+|`logsearch.config.zk_connect_string`|ZooKeeper connection string.|`EMPTY`|<ul><li>`localhost1:2181,localhost2:2181/znode`</li></ul>|
+|`logsearch.config.zk_connection_retry_time_out_ms`|The maximum elapsed time for connecting to ZooKeeper in milliseconds. 0 means retrying forever.|`EMPTY`|<ul><li>`1200000`</li></ul>|
+|`logsearch.config.zk_connection_time_out_ms`|ZooKeeper connection timeout in milliseconds|`EMPTY`|<ul><li>`30000`</li></ul>|
+|`logsearch.config.zk_root`|ZooKeeper root node where the shippers are stored. (added to the connection string)|`EMPTY`|<ul><li>`/logsearch`</li></ul>|
+|`logsearch.config.zk_session_time_out_ms`|ZooKeeper session timeout in milliseconds|`EMPTY`|<ul><li>`60000`</li></ul>|

--- a/docs/logsearch_properties.md
+++ b/docs/logsearch_properties.md
@@ -1,0 +1,134 @@
+<!---
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+## Log Search Configurations
+
+| `Name` | `Description` | `Default` | `Examples` |
+|---|---|---|---|
+|`hadoop.security.credential.provider.path`|Path to interrogate for protected credentials. (see: https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html)|`EMPTY`|<ul><li>`localjceks://file/home/mypath/my.jceks`</li></ul>|
+|`logsearch.admin.kerberos.cookie.domain`|Domain for Kerberos cookie.|localhost|<ul><li>`c6401.ambari.apache.org`</li><li>`localhost`</li></ul>|
+|`logsearch.admin.kerberos.cookie.path`|Cookie path of the kerberos cookie|/|<ul><li>`/`</li></ul>|
+|`logsearch.admin.kerberos.token.valid.seconds`|Kerberos token validity in seconds.|30|<ul><li>`30`</li></ul>|
+|`logsearch.auth.external_auth.enabled`|Enable external authentication (currently Ambari acts as an external authentication server).|false|<ul><li>`true`</li><li>`false`</li></ul>|
+|`logsearch.auth.external_auth.host_url`|External authentication server URL (host and port).|http://ip:port|<ul><li>`https://c6401.ambari.apache.org:8080`</li></ul>|
+|`logsearch.auth.external_auth.login_url`|Login URL for external authentication server ($USERNAME parameter is replaced with the Login username).|/api/v1/users/$USERNAME/privileges?fields=*|<ul><li>`/api/v1/users/$USERNAME/privileges?fields=*`</li></ul>|
+|`logsearch.auth.file.enabled`|Enable file based authentication (in json file at logsearch configuration folder).|true|<ul><li>`true`</li><li>`false`</li></ul>|
+|`logsearch.auth.jwt.audiances`|Comma separated list of acceptable audiences for the JWT token.|`EMPTY`|<ul><li>`audiance1,audiance2`</li></ul>|
+|`logsearch.auth.jwt.cookie.name`|The name of the cookie that contains the JWT token.|hadoop-jwt|<ul><li>`hadoop-jwt`</li></ul>|
+|`logsearch.auth.jwt.enabled`|Enable JWT based authentication (e.g.: for KNOX).|false|<ul><li>`true`</li><li>`false`</li></ul>|
+|`logsearch.auth.jwt.provider_url`|URL to the JWT authentication server.|`EMPTY`|<ul><li>`https://c6401.ambari.apache.org:8443/mypath`</li></ul>|
+|`logsearch.auth.jwt.public_key`|PEM formatted public key for JWT token without the header and the footer.|`EMPTY`|<ul><li>`MIGfMA0GCSqGSIb3DQEBA...`</li></ul>|
+|`logsearch.auth.jwt.query.param.original_url`|Name of the original request URL which is used to redirect to Log Search Portal.|originalUrl|<ul><li>`myUrl`</li></ul>|
+|`logsearch.auth.jwt.user.agents`|Comma separated web user agent list. (Used as prefixes)|Mozilla,Opera,Chrome|<ul><li>`Mozilla,Chrome`</li></ul>|
+|`logsearch.auth.ldap.base.dn`|Base DN of LDAP database.|`EMPTY`|<ul><li>`dc=apache,dc=org`</li></ul>|
+|`logsearch.auth.ldap.enabled`|Enable LDAP based authentication (currenty not supported).|false|<ul><li>`true`</li><li>`false`</li></ul>|
+|`logsearch.auth.ldap.group.role.attribute`|Attribute for identifying LDAP groups (group name)|cn|<ul><li>`cn`</li></ul>|
+|`logsearch.auth.ldap.group.role.map`|Map of LDAP groups to Log Search roles|`EMPTY`|<ul><li>`ROLE_CUSTOM1:ROLE_USER,ROLE_CUSTOM2:ROLE_ADMIN`</li></ul>|
+|`logsearch.auth.ldap.group.search.base`|Group search base - defines where to find LDAP groups. Won't do any authority/role mapping if this field is empty.|`EMPTY`|<ul><li>`ou=people`</li></ul>|
+|`logsearch.auth.ldap.group.search.filter`|Group search filter which is used to get membership data for a specific user|`EMPTY`|<ul><li>`(memberUid={0})`</li></ul>|
+|`logsearch.auth.ldap.manager.dn`|DN of the LDAP manger user (it is a must if LDAP groups are used).|`EMPTY`|<ul><li>`cn=admin,dc=apache,dc=org`</li></ul>|
+|`logsearch.auth.ldap.manager.password`|Password of the LDAP manager user.|`EMPTY`|<ul><li>`mypassword`</li></ul>|
+|`logsearch.auth.ldap.manager.password.file`|File that contains password of the LDAP manager user.|`EMPTY`|<ul><li>`/my/path/passwordfile`</li></ul>|
+|`logsearch.auth.ldap.password.attribute`|Password attribute for LDAP authentication|userPassword|<ul><li>`password`</li></ul>|
+|`logsearch.auth.ldap.referral.method`|Set the method to handle referrals for LDAP|ignore|<ul><li>`follow`</li></ul>|
+|`logsearch.auth.ldap.role.prefix`|Role prefix that is added for LDAP groups (as authorities)|ROLE_|<ul><li>`ROLE_`</li></ul>|
+|`logsearch.auth.ldap.url`|URL of LDAP database.|`EMPTY`|<ul><li>`ldap://localhost:389`</li></ul>|
+|`logsearch.auth.ldap.user.dn.pattern`|DN pattern that is used during login (dn should contain the username), can be used instead of user filter|`EMPTY`|<ul><li>`uid={0},ou=people`</li></ul>|
+|`logsearch.auth.ldap.user.search.base`|User search base for user search filter|`EMPTY`|<ul><li>`ou=people`</li></ul>|
+|`logsearch.auth.ldap.user.search.filter`|Used for get a user based on on LDAP search (username is the input), if it is empty, user dn pattern is used.|`EMPTY`|<ul><li>`uid={0}`</li></ul>|
+|`logsearch.auth.proxyserver.ip`|IP of trusted Knox Proxy server(s) that Log Search will trust on|`EMPTY`|<ul><li>`192.168.0.1,192.168.0.2`</li></ul>|
+|`logsearch.auth.proxyuser.groups`|List of user-groups which trusted-proxy user ‘knox’ can proxy for|*|<ul><li>`admin,user`</li></ul>|
+|`logsearch.auth.proxyuser.hosts`|List of hosts from which trusted-proxy user ‘knox’ can connect from|*|<ul><li>`host1,host2`</li></ul>|
+|`logsearch.auth.proxyuser.users`|List of users which the trusted-proxy user ‘knox’ can proxy for|knox|<ul><li>`knox,hdfs`</li></ul>|
+|`logsearch.auth.redirect.forward`|Forward redirects for HTTP calls. (useful in case of proxies)|false|<ul><li>`true`</li></ul>|
+|`logsearch.auth.simple.enabled`|Enable simple authentication. That means you won't require password to log in.|false|<ul><li>`true`</li><li>`false`</li></ul>|
+|`logsearch.auth.trusted.proxy`|A boolean property to enable/disable trusted-proxy 'knox' authentication|false|<ul><li>`true`</li></ul>|
+|`logsearch.authr.file.enabled`|A boolean property to enable/disable file based authorization|false|<ul><li>`true`</li></ul>|
+|`logsearch.authr.role.file`|Simple file that contains user/role mappings.|roles.json|<ul><li>`logsearch-roles.json`</li></ul>|
+|`logsearch.cert.algorithm`|Algorithm to generate certificates for SSL (if needed).|sha256WithRSA|<ul><li>`sha256WithRSA`</li></ul>|
+|`logsearch.cert.folder.location`|Folder where the generated certificates (SSL) will be located. Make sure the user of Log Search Server can access it.|/usr/lib/ambari-logsearch-portal/conf/keys|<ul><li>`/etc/mypath/keys`</li></ul>|
+|`logsearch.config.api.enabled`|Enable config API feature and shipperconfig API endpoints.|true|<ul><li>`false`</li></ul>|
+|`logsearch.config.api.filter.solr.enabled`|Use solr as a log level filter storage|false|<ul><li>`true`</li></ul>|
+|`logsearch.config.api.filter.zk.enabled`|Use zookeeper as a log level filter storage|false|<ul><li>`true`</li></ul>|
+|`logsearch.config.zk_acls`|ZooKeeper ACLs for handling configs. (read & write)|world:anyone:cdrwa|<ul><li>`world:anyone:r,sasl:solr:cdrwa,sasl:logsearch:cdrwa`</li></ul>|
+|`logsearch.config.zk_connect_string`|ZooKeeper connection string.|`EMPTY`|<ul><li>`localhost1:2181,localhost2:2181/znode`</li></ul>|
+|`logsearch.config.zk_connection_retry_time_out_ms`|The maximum elapsed time for connecting to ZooKeeper in milliseconds. 0 means retrying forever.|`EMPTY`|<ul><li>`1200000`</li></ul>|
+|`logsearch.config.zk_connection_time_out_ms`|ZooKeeper connection timeout in milliseconds|`EMPTY`|<ul><li>`30000`</li></ul>|
+|`logsearch.config.zk_root`|ZooKeeper root node where the shippers are stored. (added to the connection string)|`EMPTY`|<ul><li>`/logsearch`</li></ul>|
+|`logsearch.config.zk_session_time_out_ms`|ZooKeeper session timeout in milliseconds|`EMPTY`|<ul><li>`60000`</li></ul>|
+|`logsearch.hadoop.security.auth_to_local`|Rules that will be applied on authentication names and map them into local usernames.|DEFAULT|<ul><li>`RULE:[1:$1@$0](.*@EXAMPLE.COM)s/@.*//`</li><li>`DEFAULT`</li></ul>|
+|`logsearch.http.header.access-control-allow-credentials`|Access-Control-Allow-Credentials header for Log Search Server.|true|<ul><li>`true`</li><li>`false`</li></ul>|
+|`logsearch.http.header.access-control-allow-headers`|Access-Control-Allow-Headers header for Log Search Server.|origin, content-type, accept, authorization|<ul><li>`content-type, authorization`</li></ul>|
+|`logsearch.http.header.access-control-allow-methods`|Access-Control-Allow-Methods header for Log Search Server.|GET, POST, PUT, DELETE, OPTIONS, HEAD|<ul><li>`GET, POST`</li></ul>|
+|`logsearch.http.header.access-control-allow-origin`|Access-Control-Allow-Origin header for Log Search Server.|*|<ul><li>`*`</li><li>`http://c6401.ambari.apache.org`</li></ul>|
+|`logsearch.http.port`|Log Search http port|61888|<ul><li>`61888`</li><li>`8888`</li></ul>|
+|`logsearch.https.port`|Log Search https port|61889|<ul><li>`61889`</li><li>`8889`</li></ul>|
+|`logsearch.jetty.access.log.enabled`|Enable jetty access logs|false|<ul><li>`true`</li></ul>|
+|`logsearch.login.credentials.file`|Name of the credential file which contains the users for file authentication (see: logsearch.auth.file.enabled).|user_pass.json|<ul><li>`logsearch-admin.json`</li></ul>|
+|`logsearch.protocol`|Log Search Protocol (http or https)|http|<ul><li>`http`</li><li>`https`</li></ul>|
+|`logsearch.roles.allowed`|Comma separated roles for external authentication.|AMBARI.ADMINISTRATOR,CLUSTER.ADMINISTRATOR|<ul><li>`AMBARI.ADMINISTRATOR`</li></ul>|
+|`logsearch.session.timeout`|Log Search http session timeout in minutes.|30|<ul><li>`300`</li></ul>|
+|`logsearch.solr.audit.logs.alias.name`|Alias name for audit log collection (can be used for Log Search audit collection and ranger collection as well).|audit_logs_alias|<ul><li>`audit_logs_alias`</li></ul>|
+|`logsearch.solr.audit.logs.collection`|Name of Log Search audit collection.|audit_logs|<ul><li>`audit_logs`</li></ul>|
+|`logsearch.solr.audit.logs.config.name`|Solr configuration name of the audit collection.|audit_logs|<ul><li>`audit_logs`</li></ul>|
+|`logsearch.solr.audit.logs.config_set.folder`|Location of Log Search audit collection configs for Solr.|/usr/lib/ambari-logsearch-portal/conf/solr_configsets|<ul><li>`/usr/lib/ambari-logsearch-portal/conf/solr_configsets`</li></ul>|
+|`logsearch.solr.audit.logs.numshards`|Number of Solr shards for audit collection (bootstrapping).|1|<ul><li>`2`</li></ul>|
+|`logsearch.solr.audit.logs.replication.factor`|Solr replication factor for audit collection (bootstrapping).|1|<ul><li>`2`</li></ul>|
+|`logsearch.solr.audit.logs.url`|URL of Solr (non cloud mode) - currently unsupported.|`EMPTY`|<ul><li>`localhost1:8868`</li></ul>|
+|`logsearch.solr.audit.logs.zk.acls`|List of Zookeeper ACLs for Log Search audit collection (Log Search and Solr must be able to read/write collection details)|`EMPTY`|<ul><li>`world:anyone:r,sasl:solr:cdrwa,sasl:logsearch:cdrwa`</li></ul>|
+|`logsearch.solr.audit.logs.zk_connect_string`|Zookeeper connection string for Solr (used for audit log collection).|`EMPTY`|<ul><li>`localhost1:2181,localhost2:2181/mysolr_znode`</li></ul>|
+|`logsearch.solr.config_set.folder`|Location of Solr collection configs.|/usr/lib/ambari-logsearch-portal/conf/solr_configsets|<ul><li>`/usr/lib/ambari-logsearch-portal/conf/solr_configsets`</li></ul>|
+|`logsearch.solr.implicit.routing`|Use implicit routing for Solr Collections.|false|<ul><li>`true`</li></ul>|
+|`logsearch.solr.implicit.routing`|Use implicit routing for Solr Collections.|false|<ul><li>`true`</li></ul>|
+|`logsearch.solr.jaas.file`|Path of the JAAS file for Kerberos based Solr Cloud authentication.|/usr/lib/ambari-logsearch-portal/logsearch_solr_jaas.conf|<ul><li>`/my/path/jaas_file.conf`</li></ul>|
+|`logsearch.solr.kerberos.enable`|Enable Kerberos Authentication for Solr Cloud.|false|<ul><li>`true`</li><li>`false`</li></ul>|
+|`logsearch.solr.metadata`|Name of Log Search metadata collection.|logsearch_metadata|<ul><li>`logsearch_metadata`</li></ul>|
+|`logsearch.solr.metadata.config.name`|Solr configuration name of the logsearch metadata collection.|logsearch_metadata|<ul><li>`logsearch_metadata`</li></ul>|
+|`logsearch.solr.metadata.numshards`|Number of Solr shards for logsearch metadta collection (bootstrapping).|2|<ul><li>`3`</li></ul>|
+|`logsearch.solr.metadata.replication.factor`|Solr replication factor for event metadata collection (bootstrapping).|2|<ul><li>`3`</li></ul>|
+|`logsearch.solr.metadata.schema.fields.populate.interval.mins`|Interval in minutes for populating schema fiels for metadata collections.|1|<ul><li>`10`</li></ul>|
+|`logsearch.solr.ranger.audit.logs.collection`|Name of Ranger audit collections (can be used if ranger audits managed by the same Solr which is used for Log Search).|`EMPTY`|<ul><li>`ranger_audits`</li></ul>|
+|`logsearch.solr.service.logs`|Name of Log Search service log collection.|hadoop_logs|<ul><li>`hadoop_logs`</li></ul>|
+|`logsearch.solr.service.logs.config.name`|Solr configuration name of the service log collection.|hadoop_logs|<ul><li>`hadoop_logs`</li></ul>|
+|`logsearch.solr.service.logs.numshards`|Number of Solr shards for service log collection (bootstrapping).|1|<ul><li>`2`</li></ul>|
+|`logsearch.solr.service.logs.replication.factor`|Solr replication factor for service log collection (bootstrapping).|1|<ul><li>`2`</li></ul>|
+|`logsearch.solr.url`|URL of Solr (non cloud mode) - currently unsupported.|`EMPTY`|<ul><li>`localhost1:8868`</li></ul>|
+|`logsearch.solr.zk.acls`|List of Zookeeper ACLs for Log Search Collections (Log Search and Solr must be able to read/write collection details)|`EMPTY`|<ul><li>`world:anyone:r,sasl:solr:cdrwa,sasl:logsearch:cdrwa`</li></ul>|
+|`logsearch.solr.zk_connect_string`|Zookeeper connection string for Solr.|`EMPTY`|<ul><li>`localhost1:2181,localhost2:2181/mysolr_znode`</li></ul>|
+|`logsearch.spnego.kerberos.enabled`|Enable SPNEGO based authentication for Log Search Server.|false|<ul><li>`true`</li><li>`false`</li></ul>|
+|`logsearch.spnego.kerberos.host`||localhost|<ul><li>`c6401.ambari.apache.org`</li><li>`localhost`</li></ul>|
+|`logsearch.spnego.kerberos.keytab`|Keytab for SPNEGO authentication for Http requests.|`EMPTY`|<ul><li>`/etc/security/keytabs/mykeytab.keytab`</li></ul>|
+|`logsearch.spnego.kerberos.principal`|Principal for SPNEGO authentication for Http requests|`EMPTY`|<ul><li>`myuser@EXAMPLE.COM`</li></ul>|
+|`logsearch.web.audit_logs.component.labels`|Map of component component labels.|ambari:Ambari,hdfs:Hdfs,RangerAudit:Ranger|<ul><li>`ambari:Ambari,RangerAudit:ranger`</li></ul>|
+|`logsearch.web.audit_logs.field.common.excludes`|List of fields that will be excluded from metadata schema responses for every audit components.|tags,tags_str,seq_num|<ul><li>`reqUser,resp,tag_str`</li></ul>|
+|`logsearch.web.audit_logs.field.common.filterable.common.excludes`|List of fields that will be excluded from filter selection on the UI for every audit components.|`EMPTY`|<ul><li>`tag_str,resp,tag_str`</li></ul>|
+|`logsearch.web.audit_logs.field.common.labels`|Map of fields labels for audits (common).|enforcer:Access Enforcer,access:Access Type,cliIP:Client Ip,cliType:Client Type,dst:DST,evtTime:Event Time,ip:IP,logtime:Log Time,sess:Session,ugi:UGI,reqUser:User,repo:Audit Source|<ul><li>`reqUser:Req User,resp:Response`</li></ul>|
+|`logsearch.web.audit_logs.field.common.visible`|List of fields that will be displayed by default on the UI for every audit components.|access,cliIP,evtTime,repo,resource,result,reqUser|<ul><li>`reqUser,resp`</li></ul>|
+|`logsearch.web.audit_logs.field.excludes`|List of fields that will be excluded from metadata schema responses for different audit components.|`EMPTY`|<ul><li>`ambari:reqUser,resp,hdfs:ws_user,ws_role`</li></ul>|
+|`logsearch.web.audit_logs.field.filterable.excludes`|List of fields that will be excluded from filter selection on the UI for different audit components.|`EMPTY`|<ul><li>`ambari:tag_str,resp,tag_str;RangerAudit:path,ip`</li></ul>|
+|`logsearch.web.audit_logs.field.filterable.excludes`|Enable label fallback. (replace _ with spaces and capitalize properly)|true|<ul><li>`false`</li></ul>|
+|`logsearch.web.audit_logs.field.labels`|Map of fields (key-value pairs) labels for different component types.|`EMPTY`|<ul><li>`ambari#reqUser:Ambari User,ws_response:Response;RangerAudit#reqUser:Req User`</li></ul>|
+|`logsearch.web.audit_logs.field.visible`|List of fields that will be displayed by default on the UI for different audit components.|`EMPTY`|<ul><li>`ambari:reqUser,resp;RangerAudit:reqUser,repo`</li></ul>|
+|`logsearch.web.labels.service_logs.field.fallback.prefixes`|List of prefixes that should be removed during fallback of audit field labels.|ws_,std_|<ul><li>`ws_,std_,sdi_`</li></ul>|
+|`logsearch.web.labels.service_logs.field.fallback.prefixes`|List of prefixes that should be removed during fallback of service field labels.|ws_,sdi_,std_|<ul><li>`ws_,std_,sdi_`</li></ul>|
+|`logsearch.web.labels.service_logs.field.fallback.suffixes`|List of suffixes that should be removed during fallback of audit field labels.|_i,_l,_s,_b|<ul><li>`_i,_l,_s,_b`</li></ul>|
+|`logsearch.web.labels.service_logs.field.fallback.suffixes`|List of suffixes that should be removed during fallback of service field labels.|_i,_l,_s,_b|<ul><li>`_i,_l,_s,_b`</li></ul>|
+|`logsearch.web.service_logs.component.labels`|Map of serivce component labels.|`EMPTY`|<ul><li>`ambari_agent:Ambari Agent,ambari_server:Ambari Servcer`</li></ul>|
+|`logsearch.web.service_logs.field.excludes`|List of fields that will be excluded from metadata schema responses.|id,tags,text,message,seq_num,case_id,bundle_id,rowtype,event_count|<ul><li>`seq_num,tag`</li></ul>|
+|`logsearch.web.service_logs.field.filterable.excludes`|List of fields that will be excluded from filter selection on the UI.|`EMPTY`|<ul><li>`path,method,logger_name`</li></ul>|
+|`logsearch.web.service_logs.field.labels`|Map of serivce field labels.|log_message:Message,type:Component,logtime:Log Time,thread_name:Thread|<ul><li>`log_message:Message,ip:IP Address`</li></ul>|
+|`logsearch.web.service_logs.field.visible`|List of fields that will be displayed by default on the UI.|log_message,level,logtime,type|<ul><li>`log_message,path,logtime`</li></ul>|
+|`logsearch.web.service_logs.group.labels`|Map of serivce group labels|`EMPTY`|<ul><li>`ambari:Ambari,yarn:YARN`</li></ul>|

--- a/docs/schema_fields.md
+++ b/docs/schema_fields.md
@@ -1,0 +1,16 @@
+<!---
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->

--- a/docs/shipper_configurations.md
+++ b/docs/shipper_configurations.md
@@ -1,0 +1,390 @@
+<!---
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+## Log Feeder Shipper Descriptor
+
+### Top Level Descriptors
+
+Input, Filter and Output configurations are defined in 3 (at least) different files. (note: there can be multiple input configuration files, but only 1 output and global configuration)
+
+input.config-myservice.json example:
+```json
+{
+  "input" : [
+  ],
+  "filter" : [
+  ]
+}
+```
+output.config.json example:
+```json
+{
+  "output" : [
+  ]
+}
+```
+global.config.json example:
+```json
+{
+  "global" : {
+    "source" : "file",
+    "add_fields":{
+      "cluster":"cl1"
+    },
+    "tail" : "true"
+  }
+}
+```
+| `Path` | `Description` | `Default` | `Examples` |
+|---|---|---|---|
+|`/filter`|A list of filter descriptions|`EMPTY`|<ul><li>`{"filter" : [ {"filter": "json", "conditions": {"fields": { "type": ["mytype1", "mytype2"]} } } ]}`</li></ul>|
+|`/input`|A list of input descriptions|`EMPTY`|<ul><li>`{"input" : [ {"type": "myinput_service_type"}] }`</li></ul>|
+|`/output`|A list of output descriptors|`{}`|<ul><li>`{"output": [{"is_enabled" : "true", "destination": "solr", "myfield": "myvalue"}]`</li></ul>|
+|`/global`|A map that contains field/value pairs|`EMPTY`|<ul><li>`{"global": {"myfield": "myvalue"}}`</li></ul>|
+
+### Input Descriptor
+
+Input configurations (for monitoring logs) can be defined in the input descriptor section.
+Example:
+```json
+{
+  "input" : [
+    {
+      "type": "simple_service",
+      "rowtype": "service",
+      "path": "/var/logs/my/service/service_sample.txt",
+      "group": "Ambari",
+      "cache_enabled": "true",
+      "cache_key_field": "log_message",
+      "cache_size": "50"
+    },
+    {
+      "type": "simple_service_json",
+      "rowtype": "service",
+      "path": "/var/logs/my/service/service_sample.json",
+      "properties": {
+        "myKey1" : "myValue1",
+        "myKey2" : "myValue2"
+      }
+    },
+    {
+      "type": "simple_audit_service",
+      "rowtype": "audit",
+      "path": "/var/logs/my/service/service_audit_sample.txt",
+      "is_enabled": "true",
+      "add_fields": {
+        "logType": "AmbariAudit",
+        "enforcer": "ambari-acl",
+        "repoType": "1",
+        "repo": "ambari",
+        "level": "INFO"
+      }
+    },
+    {
+     "type": "wildcard_log_service",
+     "rowtype": "service",
+     "path": "/var/logs/my/service/*/service_audit_sample.txt",
+     "init_default_fields" : "true",
+     "detach_interval_min": "50",
+     "detach_time_min" : "300",
+     "path_update_interval_min" : "10",
+     "max_age_min" : "800"
+    },
+    {
+      "type": "service_socket",
+      "rowtype": "service",
+      "port": 61999,
+      "protocol" : "tcp",
+      "secure" : "false",
+      "source" : "socket",
+      "log4j": "true"
+    },
+    {
+      "type": "docker_service",
+      "rowtype": "service",
+      "docker" : "true",
+      "default_log_levels" : [
+         "FATAL", "ERROR", "WARN", "INFO", "DEBUG"
+      ]
+    }
+  ]
+}
+```
+Built-in input shipper configurations:
+| `Path` | `Description` | `Default` | `Examples` |
+|---|---|---|---|
+|`/input/[]/add_fields`|The element contains field_name: field_value pairs which will be added to each rows data.|`EMPTY`|<ul><li>`"cluster":"cluster_name"`</li></ul>|
+|`/input/[]/cache_dedup_interval`|The maximum interval in ms which may pass between two identical log messages to filter the latter out.|1000|<ul><li>`500`</li></ul>|
+|`/input/[]/cache_enabled`|Allows the input to use a cache to filter out duplications.|false|<ul><li>`true`</li><li>`false`</li></ul>|
+|`/input/[]/cache_key_field`|Specifies the field for which to use the cache to find duplications of.|log_message|<ul><li>`some_field_prone_to_repeating_value`</li></ul>|
+|`/input/[]/cache_last_dedup_enabled`|Allow to filter out entries which are same as the most recent one irrelevant of it's time.|false|<ul><li>`true`</li><li>`false`</li></ul>|
+|`/input/[]/cache_size`|The number of entries to store in the cache.|100|<ul><li>`50`</li></ul>|
+|`/input/[]/checkpoint_interval_ms`|The time interval in ms when the checkpoint file should be updated.|5000|<ul><li>`10000`</li></ul>|
+|`/input/[]/class_name`|Custom class which implements an input type|`EMPTY`|<ul><li>`org.example.MyInputSource`</li></ul>|
+|`/input/[]/copy_file`|Should the file be copied (only if not processed).|false|<ul><li>`true`</li><li>`false`</li></ul>|
+|`/input/[]/default_log_levels`|Use these as default log levels for the input - overrides the global default log levels.|`EMPTY`|<ul><li>`default_log_levels: ["INFO", "WARN"]`</li></ul>|
+|`/input/[]/detach_interval_min`|The period in minutes for checking which files are too old (default: 300)|1800|<ul><li>`60`</li></ul>|
+|`/input/[]/detach_time_min`|The period in minutes when the application flags a file is too old (default: 2000)|2000|<ul><li>`60`</li></ul>|
+|`/input/[]/docker`|Input comes from a docker container.|false|<ul><li>`true`</li><li>`false`</li></ul>|
+|`/input/[]/gen_event_md5`|Generate an event_md5 field for each row by creating a hash of the row data.|true|<ul><li>`true`</li><li>`false`</li></ul>|
+|`/input/[]/group`|Group of the input type.|`EMPTY`|<ul><li>`Ambari`</li><li>`Yarn`</li></ul>|
+|`/input/[]/init_default_fields`|Init default fields (ip, path etc.) before applying the filter.|false|<ul><li>`true`</li><li>`false`</li></ul>|
+|`/input/[]/is_enabled`|A flag to show if the input should be used.|true|<ul><li>`true`</li><li>`false`</li></ul>|
+|`/input/[]/log4j`|Use Log4j serialized objects (e.g.: SocketAppender)|false|<ul><li>`true`</li></ul>|
+|`/input/[]/max_age_min`|If the file has not modified for long (this time value in minutes), then the checkpoint file can be deleted.|0|<ul><li>`2000`</li></ul>|
+|`/input/[]/path`|The path of the source, may contain '*' characters too.|`EMPTY`|<ul><li>`/var/log/ambari-logsearch-logfeeder/logsearch-logfeeder.json`</li><li>`/var/log/zookeeper/zookeeper*.log`</li></ul>|
+|`/input/[]/path_update_interval_min`|The period in minutes for checking new files (default: 5, based on detach values, its possible that a new input wont be monitored)|5|<ul><li>`5`</li></ul>|
+|`/input/[]/port`|Unique port for specific socket input|`EMPTY`|<ul><li>`61999`</li></ul>|
+|`/input/[]/process_file`|Should the file be processed.|true|<ul><li>`true`</li><li>`false`</li></ul>|
+|`/input/[]/properties`|Custom key value pairs|`EMPTY`|<ul><li>`{k1 : v1, k2: v2}`</li></ul>|
+|`/input/[]/protocol`|Protocol type for socket server (tcp / udp - udp is not supported right now)|tcp|<ul><li>`udp`</li><li>`tcp`</li></ul>|
+|`/input/[]/rowtype`|The type of the row.|`EMPTY`|<ul><li>`service`</li><li>`audit`</li></ul>|
+|`/input/[]/s3_access_key`|The access key used for AWS credentials. (Not supported yet through shipper configurations)|`EMPTY`||
+|`/input/[]/s3_endpoint`|Endpoint URL for S3. (Not supported yet through shipper configurations)|`EMPTY`||
+|`/input/[]/s3_secret_key`|The secret key used for AWS credentials. (Not supported yet through shipper configurations)|`EMPTY`||
+|`/input/[]/secure`|Use SSL|false|<ul><li>`true`</li></ul>|
+|`/input/[]/source`|The type of the input source.|`EMPTY`|<ul><li>`file`</li><li>`s3_file`</li></ul>|
+|`/input/[]/tail`|The input should check for only the latest file matching the pattern, not all of them.|true|<ul><li>`true`</li><li>`false`</li></ul>|
+|`/input/[]/type`|The log id for this source.|`EMPTY`|<ul><li>`zookeeper`</li><li>`ambari_server`</li></ul>|
+|`/input/[]/use_event_md5_as_id`|Generate an id for each row by creating a hash of the row data.|false|<ul><li>`true`</li><li>`false`</li></ul>|
+
+### Filter Descriptor
+
+Filter configurations can be defined in the filter descriptor section.
+Example:
+```json
+{
+  "input" : [
+  ],
+  "filter": [
+    {
+      "filter": "json",
+      "conditions": {
+        "fields": {
+          "type": [
+            "simple_service_json"
+          ]
+        }
+      }
+    }
+    {
+      "filter": "grok",
+      "deep_extract": "false",
+      "conditions":{
+        "fields":{
+          "type":[
+            "simple_service",
+            "simple_audit_service",
+            "docker_service"
+          ]
+        }
+      },
+      "log4j_format":"%d{ISO8601} %5p [%t] %c{1}:%L - %m%n",
+      "multiline_pattern":"^(%{TIMESTAMP_ISO8601:logtime})",
+      "message_pattern":"(?m)^%{TIMESTAMP_ISO8601:logtime}%{SPACE}%{LOGLEVEL:level}%{SPACE}\\[%{DATA:thread_name}\\]%{SPACE}%{JAVACLASS:logger_name}:%{INT:line_number}%{SPACE}-%{SPACE}%{GREEDYDATA:log_message}",
+      "post_map_values":{
+        "logtime":{
+          "map_date":{
+            "target_date_pattern":"yyyy-MM-dd HH:mm:ss,SSS"
+          }
+        }
+      }
+    },
+    {
+      "filter": "grok",
+      "conditions": {
+        "fields": {
+          "type": [
+            "ambari_audit"
+          ]
+        }
+      },
+      "log4j_format": "%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n",
+      "multiline_pattern": "^(%{TIMESTAMP_ISO8601:evtTime})",
+      "message_pattern": "(?m)^%{TIMESTAMP_ISO8601:evtTime},%{SPACE}%{GREEDYDATA:log_message}",
+      "post_map_values": {
+        "evtTime": {
+          "map_date": {
+            "target_date_pattern": "yyyy-MM-dd'T'HH:mm:ss.SSSXX"
+          }
+        }
+      }
+    },
+    {
+      "filter": "keyvalue",
+      "sort_order": 1,
+      "conditions": {
+        "fields": {
+          "type": [
+            "ambari_audit"
+          ]
+        }
+      },
+      "source_field": "log_message",
+      "field_split": ", ",
+      "value_borders": "()",
+      "post_map_values": {
+        "User": {
+          "map_field_value": {
+            "pre_value": "null",
+            "post_value": "unknown"
+          },
+          "map_field_name": {
+            "new_field_name": "reqUser"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+Built-in filter shipper configurations:
+| `Path` | `Description` | `Default` | `Examples` |
+|---|---|---|---|
+|`/filter/[]/conditions`|The conditions of which input to filter.|`EMPTY`||
+|`/filter/[]/conditions/fields`|The fields in the input element of which's value should be met.|`EMPTY`|<ul><li>`"fields"{"type": ["hdfs_audit", "hdfs_datanode"]}`</li></ul>|
+|`/filter/[]/conditions/fields/type`|The acceptable values for the type field in the input element.|`EMPTY`|<ul><li>`"ambari_server"`</li><li>`"spark_jobhistory_server", "spark_thriftserver", "livy_server"`</li></ul>|
+|`/filter/[]/deep_extract`|Keep the full named regex collection for Grok filters.|`EMPTY`|<ul><li>`true`</li></ul>|
+|`/filter/[]/field_split`|The string that splits the key-value pairs.|\t|<ul><li>` `</li><li>`,`</li></ul>|
+|`/filter/[]/filter`|The type of the filter.|`EMPTY`|<ul><li>`grok`</li><li>`keyvalue`</li><li>`json`</li></ul>|
+|`/filter/[]/is_enabled`|A flag to show if the filter should be used.|true|<ul><li>`true`</li><li>`false`</li></ul>|
+|`/filter/[]/log4j_format`|The log4j pattern of the log, not used, it is only there for documentation.|`EMPTY`|<ul><li>`%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n`</li></ul>|
+|`/filter/[]/message_pattern`|The grok pattern to use to parse the log entry.|`EMPTY`|<ul><li>`(?m)^%{TIMESTAMP_ISO8601:logtime}%{SPACE}-%{SPACE}%{LOGLEVEL:level}%{SPACE}\[%{DATA:thread_name}\@%{INT:line_number}\]%{SPACE}-%{SPACE}%{GREEDYDATA:log_message}`</li></ul>|
+|`/filter/[]/multiline_pattern`|The grok pattern that shows that the line is not a log line on it's own but the part of a multi line entry.|`EMPTY`|<ul><li>`^(%{TIMESTAMP_ISO8601:logtime})`</li></ul>|
+|`/filter/[]/post_map_values`|Mappings done after the filtering provided it's result.|`EMPTY`||
+|`/filter/[]/remove_source_field`|Remove the source field after the filter is applied.|false|<ul><li>`true`</li><li>`false`</li></ul>|
+|`/filter/[]/skip_on_error`|Skip filter if an error occurred during applying the grok filter.|`EMPTY`|<ul><li>`true`</li></ul>|
+|`/filter/[]/sort_order`|Describes the order in which the filters should be applied.|`EMPTY`|<ul><li>`1`</li><li>`3`</li></ul>|
+|`/filter/[]/source_field`|The source of the filter, must be set for keyvalue filters.|log_message|<ul><li>`field_further_to_filter`</li></ul>|
+|`/filter/[]/value_borders`|The borders around the value, must be 2 characters long, first before it, second after it.|`EMPTY`|<ul><li>`()`</li><li>`[]`</li><li>`{}`</li></ul>|
+|`/filter/[]/value_split`|The string that separates keys from values.|=|<ul><li>`:`</li><li>`->`</li></ul>|
+
+### Mapper Descriptor
+
+Mapper configurations are defined inside filters, it can alter fields.
+Example:
+```json
+{
+  "input": [
+  ],
+  "filter": [
+    {
+      "filter": "keyvalue",
+      "sort_order": 1,
+      "conditions": {
+        "fields": {
+          "type": [
+            "ambari_audit"
+          ]
+        }
+      },
+      "source_field": "log_message",
+      "field_split": ", ",
+      "value_borders": "()",
+      "post_map_values": {
+        "Status": {
+          "map_field_value": {
+            "pre_value": "null",
+            "post_value": "unknown"
+          },
+          "map_field_name": {
+            "new_field_name": "ws_status"
+          }
+        },
+        "StatusWithRepeatedKeys": [
+          {
+            "map_field_value": {
+              "pre_value": "Failed",
+              "post_value": "0"
+            }
+          },
+          {
+            "map_field_value": {
+              "pre_value": "Failed to queue",
+              "post_value": "0"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+Built-in mapper shipper configurations:
+| `Path` | `Description` | `Default` | `Examples` |
+|---|---|---|---|
+|`/filter/[]/post_map_values/{field_name}/[]/map_anonymize/hide_char`|The character to hide with|*|<ul><li>`X`</li><li>`-`</li></ul>|
+|`/filter/[]/post_map_values/{field_name}/[]/map_anonymize/pattern`|The pattern to use to identify parts to anonymize. The parts to hide should be marked with the "<hide>" string.|`EMPTY`|<ul><li>`Some secret is here: <hide>, and another one is here: <hide>`</li></ul>|
+|`/filter/[]/post_map_values/{field_name}/[]/map_copy/copy_name`|The name of the copied field|`EMPTY`|<ul><li>`new_name`</li></ul>|
+|`/filter/[]/post_map_values/{field_name}/[]/map_custom/class_name`|Custom class which implements a mapper type|`EMPTY`|<ul><li>`org.example.MyMapper`</li></ul>|
+|`/filter/[]/post_map_values/{field_name}/[]/map_custom/properties`|Custom key value pairs|`EMPTY`|<ul><li>`{k1 : v1, k2: v2}`</li></ul>|
+|`/filter/[]/post_map_values/{field_name}/[]/map_date/src_date_pattern`|If it is specified than the mapper converts from this format to the target, and also adds missing year|`EMPTY`|<ul><li>`MMM dd HH:mm:ss`</li></ul>|
+|`/filter/[]/post_map_values/{field_name}/[]/map_date/target_date_pattern`|If 'epoch' then the field is parsed as seconds from 1970, otherwise the content used as pattern|`EMPTY`|<ul><li>`yyyy-MM-dd HH:mm:ss,SSS`</li><li>`epoch`</li></ul>|
+|`/filter/[]/post_map_values/{field_name}/[]/map_field_name/new_field_name`|The name of the renamed field|`EMPTY`|<ul><li>`new_name`</li></ul>|
+|`/filter/[]/post_map_values/{field_name}/[]/map_field_value/post_value`|The value to which the field is modified to|`EMPTY`|<ul><li>`new_value`</li></ul>|
+|`/filter/[]/post_map_values/{field_name}/[]/map_field_value/pre_value`|The value that the field must match (ignoring case) to be mapped|`EMPTY`|<ul><li>`old_value`</li></ul>|
+
+### Output Descriptor
+
+Output configurations can be defined in the output descriptor section. (it can support any extra - output specific - key value pairs)
+Example:
+
+```json
+{
+  "output": [
+    {
+      "is_enabled": "true",
+      "comment": "Output to solr for service logs",
+      "collection" : "hadoop_logs",
+      "destination": "solr",
+      "zk_connect_string": "localhost:9983",
+      "type": "service",
+      "conditions": {
+        "fields": {
+          "rowtype": [
+            "service"
+          ]
+        }
+      }
+    },
+    {
+      "comment": "Output to solr for audit records",
+      "is_enabled": "true",
+      "collection" : "audit_logs",
+      "destination": "solr",
+      "zk_connect_string": "localhost:9983",
+      "type": "audit",
+      "conditions": {
+        "fields": {
+          "rowtype": [
+            "audit"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+Built-in output shipper configurations:
+| `Path` | `Description` | `Default` | `Examples` |
+|---|---|---|---|
+|`/output/[]/conditions`|The conditions of which input to filter.|`EMPTY`||
+|`/output/[]/conditions/fields`|The fields in the input element of which's value should be met.|`EMPTY`|<ul><li>`"fields"{"type": ["hdfs_audit", "hdfs_datanode"]}`</li></ul>|
+|`/output/[]/conditions/fields/type`|The acceptable values for the type field in the input element.|`EMPTY`|<ul><li>`"ambari_server"`</li><li>`"spark_jobhistory_server", "spark_thriftserver", "livy_server"`</li></ul>|
+|`/output/[]/is_enabled`|A flag to show if the output should be used.|true|<ul><li>`true`</li><li>`false`</li></ul>|
+|`/output/[]/destination`|Alias of a supported output (e.g.: solr). The class-alias mapping should exist in the alias config.|`EMPTY`|<ul><li>`"solr"`</li><li>`"hdfs"`</li></ul>|
+|`/output/[]/type`|Output type name, right now it can be service or audit|`EMPTY`|<ul><li>`"service"`</li><li>`"audit"`</li></ul>|

--- a/docs/shipper_configurations.md
+++ b/docs/shipper_configurations.md
@@ -51,7 +51,7 @@ global.config.json example:
 ```
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
-|`/filter`|A list of filter descriptions|`EMPTY`|<ul><li>`{"filter" : [ {"filter": "json", "conditions": {"fields": { "type": ["mytype1", "mytype2"]} } } ]}`</li></ul>|
+|`/filter`|A list of filter descriptions|`EMPTY`|<ul><li>`{"filter" : [ {"filter": "json", "conditions": {"fields": { "type": ["logsearch_app", "logsearch_perf"]} } } ]}`</li></ul>|
 |`/input`|A list of input descriptions|`EMPTY`|<ul><li>`{"input" : [ {"type": "myinput_service_type"}] }`</li></ul>|
 |`/output`|A list of output descriptors|`{}`|<ul><li>`{"output": [{"is_enabled" : "true", "destination": "solr", "myfield": "myvalue"}]`</li></ul>|
 |`/global`|A map that contains field/value pairs|`EMPTY`|<ul><li>`{"global": {"myfield": "myvalue"}}`</li></ul>|
@@ -153,9 +153,6 @@ Built-in input shipper configurations:
 |`/input/[]/properties`|Custom key value pairs|`EMPTY`|<ul><li>`{k1 : v1, k2: v2}`</li></ul>|
 |`/input/[]/protocol`|Protocol type for socket server (tcp / udp - udp is not supported right now)|tcp|<ul><li>`udp`</li><li>`tcp`</li></ul>|
 |`/input/[]/rowtype`|The type of the row.|`EMPTY`|<ul><li>`service`</li><li>`audit`</li></ul>|
-|`/input/[]/s3_access_key`|The access key used for AWS credentials. (Not supported yet through shipper configurations)|`EMPTY`||
-|`/input/[]/s3_endpoint`|Endpoint URL for S3. (Not supported yet through shipper configurations)|`EMPTY`||
-|`/input/[]/s3_secret_key`|The secret key used for AWS credentials. (Not supported yet through shipper configurations)|`EMPTY`||
 |`/input/[]/secure`|Use SSL|false|<ul><li>`true`</li></ul>|
 |`/input/[]/source`|The type of the input source.|`EMPTY`|<ul><li>`file`</li><li>`s3_file`</li></ul>|
 |`/input/[]/tail`|The input should check for only the latest file matching the pattern, not all of them.|true|<ul><li>`true`</li><li>`false`</li></ul>|

--- a/docs/shipper_configurations.md
+++ b/docs/shipper_configurations.md
@@ -124,7 +124,6 @@ Example:
   ]
 }
 ```
-Built-in input shipper configurations:
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
 |`/input/[]/add_fields`|The element contains field_name: field_value pairs which will be added to each rows data.|`EMPTY`|<ul><li>`"cluster":"cluster_name"`</li></ul>|
@@ -162,6 +161,25 @@ Built-in input shipper configurations:
 ### Filter Descriptor
 
 Filter configurations can be defined in the filter descriptor section.
+- Sample 1 for example (json - simple_service_json):
+```json
+{"level":"WARN","file":"ClientCnxn.java","thread_name":"zkCallback-6-thread-10-SendThread(c6402.ambari.apache.org:2181)","line_number":1102,"log_message":"Session 0x355e0023b38001d for server null, unexpected error, closing socket connection and attempting reconnect\njava.net.SocketException: Network is unreachable\n\tat sun.nio.ch.Net.connect0(Native Method)\n\tat sun.nio.ch.Net.connect(Net.java:454)\n\tat sun.nio.ch.Net.connect(Net.java:446)\n\tat sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:648)\n\tat org.apache.zookeeper.ClientCnxnSocketNIO.registerAndConnect(ClientCnxnSocketNIO.java:277)\n\tat org.apache.zookeeper.ClientCnxnSocketNIO.connect(ClientCnxnSocketNIO.java:287)\n\tat org.apache.zookeeper.ClientCnxn$SendThread.startConnect(ClientCnxn.java:967)\n\tat org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1003)\n","logger_name":"org.apache.zookeeper.ClientCnxn","logtime":"1468406756757"}
+```
+- Sample 2 for example (grok - simple_service):
+```text
+2016-07-13 10:45:49,640 [WARN] Sample log line 1 - warn level
+that is a multiline
+2016-07-13 10:45:49,640 [ERROR] Sample log line 2 - error level
+2016-07-13 10:45:50,351 [INFO] Sample log line 3 - info level
+```
+- Sample 3 for example (grok + key/value - ambari_audit):
+```text
+2016-10-03T16:26:13.333Z, User(admin), RemoteIp(192.168.64.1), Operation(User login), Roles(
+    Ambari: Ambari Administrator
+), Status(Success)
+2016-10-03T16:26:54.834Z, User(admin), RemoteIp(192.168.64.1), Operation(Repository update), RequestType(PUT), url(http://c6401.ambari.apache.org:8080/api/v1/stacks/HDP/versions/2.5/operating_systems/redhat6/repositories/HDP-UTILS-1.1.0.21), ResultStatus(200 OK), Stack(HDP), Stack version(2.5), OS(redhat6), Repo id(HDP-UTILS-1.1.0.21), Base URL(http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos6)
+2016-10-03T16:26:54.845Z, User(admin), RemoteIp(192.168.64.1), Operation(Repository update), RequestType(PUT), url(http://c6401.ambari.apache.org:8080/api/v1/stacks/HDP/versions/2.5/operating_systems/redhat7/repositories/HDP-2.5), ResultStatus(200 OK), Stack(HDP), Stack version(2.5), OS(redhat7), Repo id(HDP-2.5), Base URL(http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.5.0.0/)
+```
 Example:
 ```json
 {
@@ -177,7 +195,7 @@ Example:
           ]
         }
       }
-    }
+    },
     {
       "filter": "grok",
       "deep_extract": "false",
@@ -190,9 +208,9 @@ Example:
           ]
         }
       },
-      "log4j_format":"%d{ISO8601} %5p [%t] %c{1}:%L - %m%n",
+      "log4j_format":"# can be anything - only use it as marker/helper as it does not supported yet",
       "multiline_pattern":"^(%{TIMESTAMP_ISO8601:logtime})",
-      "message_pattern":"(?m)^%{TIMESTAMP_ISO8601:logtime}%{SPACE}%{LOGLEVEL:level}%{SPACE}\\[%{DATA:thread_name}\\]%{SPACE}%{JAVACLASS:logger_name}:%{INT:line_number}%{SPACE}-%{SPACE}%{GREEDYDATA:log_message}",
+      "message_pattern":"(?m)^%{TIMESTAMP_ISO8601:logtime}%{SPACE}\\[%{LOGLEVEL:level}\\]%{SPACE}%{GREEDYDATA:log_message}}",
       "post_map_values":{
         "logtime":{
           "map_date":{
@@ -249,7 +267,6 @@ Example:
   ]
 }
 ```
-Built-in filter shipper configurations:
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
 |`/filter/[]/conditions`|The conditions of which input to filter.|`EMPTY`||
@@ -321,7 +338,6 @@ Example:
   ]
 }
 ```
-Built-in mapper shipper configurations:
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
 |`/filter/[]/post_map_values/{field_name}/[]/map_anonymize/hide_char`|The character to hide with|*|<ul><li>`X`</li><li>`-`</li></ul>|
@@ -376,7 +392,6 @@ Example:
   ]
 }
 ```
-Built-in output shipper configurations:
 | `Path` | `Description` | `Default` | `Examples` |
 |---|---|---|---|
 |`/output/[]/conditions`|The conditions of which input to filter.|`EMPTY`||

--- a/docs/shipper_configurations.md
+++ b/docs/shipper_configurations.md
@@ -66,7 +66,7 @@ Example:
     {
       "type": "simple_service",
       "rowtype": "service",
-      "path": "/var/logs/my/service/service_sample.txt",
+      "path": "/var/logs/my/service/service_sample.log",
       "group": "Ambari",
       "cache_enabled": "true",
       "cache_key_field": "log_message",
@@ -84,7 +84,7 @@ Example:
     {
       "type": "simple_audit_service",
       "rowtype": "audit",
-      "path": "/var/logs/my/service/service_audit_sample.txt",
+      "path": "/var/logs/my/service/service_audit_sample.log",
       "is_enabled": "true",
       "add_fields": {
         "logType": "AmbariAudit",
@@ -97,7 +97,7 @@ Example:
     {
      "type": "wildcard_log_service",
      "rowtype": "service",
-     "path": "/var/logs/my/service/*/service_audit_sample.txt",
+     "path": "/var/logs/my/service/*/service_audit_sample.log",
      "init_default_fields" : "true",
      "detach_interval_min": "50",
      "detach_time_min" : "300",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,3 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+site_name: Ambari Log Search
+site_dir: mkdocs-site
+nav:
+- Home: index.md
+- User Guide:
+  - Getting Started: getting_started.md
+  - Add New Service: add_new_input.md
+  - Schema Fields: schema_fields.md
+  - Cloud Mode: cloud_mode.md
+  - Configuration:
+    - Log Search properties: logsearch_properties.md
+    - Log Feeder properties: logfeeder_properties.md
+    - Shipper configurations: shipper_configurations.md
+- Docs: docs.md
+- About: about.md

--- a/pom.xml
+++ b/pom.xml
@@ -378,6 +378,7 @@
             <exclude>**/dist/**</exclude>
             <exclude>.repository/**</exclude>
             <exclude>k8s/**</exclude>
+            <exclude>mkdocs-site/**</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,6 @@
     <logsearch.docker.tag>latest</logsearch.docker.tag>
     <fasterxml-jackson.version>2.9.5</fasterxml-jackson.version>
     <log4j2.version>2.11.1</log4j2.version>
-    <swagger-ui.version>3.19.0</swagger-ui.version>
   </properties>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
     <logsearch.docker.tag>latest</logsearch.docker.tag>
     <fasterxml-jackson.version>2.9.5</fasterxml-jackson.version>
     <log4j2.version>2.11.1</log4j2.version>
+    <swagger-ui.version>3.19.0</swagger-ui.version>
   </properties>
 
   <licenses>
@@ -365,6 +366,7 @@
             <exclude>**/*.log</exclude>
             <exclude>**/*.txt</exclude>
             <exclude>**/*.story</exclude>
+            <exclude>**/*.yaml</exclude>
             <exclude>**/*.editorconfig</exclude>
             <exclude>**/*.iml</exclude>
             <exclude>**/src/vendor/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
     <logsearch.docker.tag>latest</logsearch.docker.tag>
     <fasterxml-jackson.version>2.9.5</fasterxml-jackson.version>
     <log4j2.version>2.11.1</log4j2.version>
+    <swagger-ui.version>3.19.0</swagger-ui.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
# What changes were proposed in this pull request?
- fix some docs
- generate output shipper configs as well
- add mkdocs support
- put javadoc + rest api doc as well to generated site
- add markdown skeletons (i will need to fill those + add nice pictures)

note: probably we will use docker for mkdocs build, right now it is expected to be installed

## How was this patch tested?
full test: `make serve-site`, it can take long because of 2 web build, if modules are already installed then its enough to run: `make javadoc`, `make prop-docs-only` then `make serve-site-only`

Please review @g-boros 
