### PR TITLE
[Ambari-23820] [Log Search UI] add different options of hostname display

### DIFF
--- a/ambari-logsearch-web/src/app/app.module.ts
+++ b/ambari-logsearch-web/src/app/app.module.ts
@@ -41,7 +41,7 @@ import { HttpClientService } from '@app/services/http-client.service';
 import { UtilsService } from '@app/services/utils.service';
 import { LogsContainerService } from '@app/services/logs-container.service';
 import { ComponentGeneratorService } from '@app/services/component-generator.service';
-import { UserSettingsService } from '@app/services/user-settings.service';
+import { ServerSettingsService } from '@app/services/server-settings.service';
 
 import { AppSettingsService } from '@app/services/storage/app-settings.service';
 import { AppStateService } from '@app/services/storage/app-state.service';
@@ -115,11 +115,15 @@ import { LogsBreadcrumbsResolverService } from '@app/services/logs-breadcrumbs-r
 import { LogsFilteringUtilsService } from '@app/services/logs-filtering-utils.service';
 import { LogsStateService } from '@app/services/storage/logs-state.service';
 import { LoginScreenGuardService } from '@app/services/login-screen-guard.service';
+import { UserSettingsService } from '@app/services/user-settings.service';
 
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import { UserSettingsEffects } from '@app/store/effects/user-settings.effects';
 import { FilterHistoryManagerComponent } from './components/filter-history-manager/filter-history-manager.component';
 import { AuditLogReposEffects } from './store/effects/audit-log-repos.effects';
+
+import { HostNamePipe } from '@app/pipes/host-name.pipe';
 
 @NgModule({
   declarations: [
@@ -165,7 +169,8 @@ import { AuditLogReposEffects } from './store/effects/audit-log-repos.effects';
     AuditLogFieldLabelPipe,
     BreadcrumbsComponent,
     ClusterFilterComponent,
-    FilterHistoryManagerComponent
+    FilterHistoryManagerComponent,
+    HostNamePipe
   ],
   imports: [
     BrowserModule,
@@ -198,8 +203,9 @@ import { AuditLogReposEffects } from './store/effects/audit-log-repos.effects';
     AppRoutingModule,
 
     EffectsModule.run(AuthEffects),
-    EffectsModule.run(NotificationEffects),
-    EffectsModule.run(AuditLogReposEffects)
+    EffectsModule.run(AuditLogReposEffects),
+    EffectsModule.run(UserSettingsEffects),
+    EffectsModule.run(NotificationEffects)
 
   ],
   providers: [
@@ -208,7 +214,7 @@ import { AuditLogReposEffects } from './store/effects/audit-log-repos.effects';
     RoutingUtilsService,
     LogsContainerService,
     ComponentGeneratorService,
-    UserSettingsService,
+    ServerSettingsService,
     AppSettingsService,
     AppStateService,
     AuditLogsService,
@@ -232,7 +238,8 @@ import { AuditLogReposEffects } from './store/effects/audit-log-repos.effects';
     ClusterSelectionService,
     LogsFilteringUtilsService,
     LogsStateService,
-    LoginScreenGuardService
+    LoginScreenGuardService,
+    UserSettingsService
   ],
   bootstrap: [AppComponent],
   entryComponents: [

--- a/ambari-logsearch-web/src/app/classes/components/graph/graph.component.ts
+++ b/ambari-logsearch-web/src/app/classes/components/graph/graph.component.ts
@@ -17,20 +17,35 @@
  */
 
 import {
-  AfterViewInit, OnChanges, SimpleChanges, ViewChild, ElementRef, Input, Output, EventEmitter, OnInit, OnDestroy
+  AfterViewInit,
+  OnChanges,
+  SimpleChanges,
+  ViewChild,
+  ElementRef,
+  Input,
+  Output,
+  EventEmitter,
+  OnInit,
+  OnDestroy
 } from '@angular/core';
 import * as d3 from 'd3';
 import * as d3sc from 'd3-scale-chromatic';
-import {Observable} from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/observable/fromEvent';
 import 'rxjs/add/operator/debounceTime';
 import {
-GraphPositionOptions, GraphMarginOptions, GraphTooltipInfo, LegendItem, GraphEventData, GraphEmittedEvent
+  GraphPositionOptions,
+  GraphMarginOptions,
+  GraphTooltipInfo,
+  LegendItem,
+  GraphEventData,
+  GraphEmittedEvent
 } from '@app/classes/graph';
-import {HomogeneousObject} from '@app/classes/object';
-import {ServiceInjector} from '@app/classes/service-injector';
-import {UtilsService} from '@app/services/utils.service';
-import {Subscription} from 'rxjs/Subscription';
+import { HomogeneousObject } from '@app/classes/object';
+import { ServiceInjector } from '@app/classes/service-injector';
+import { UtilsService } from '@app/services/utils.service';
+import { Subscription } from 'rxjs/Subscription';
 
 export const graphColors = [
   '#41bfae',
@@ -197,8 +212,6 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnInit, OnDestr
    */
   private tooltipOnTheLeft = false;
 
-  protected subscriptions: Subscription[] = [];
-
   /**
    * This will return the information about the used levels and the connected colors and labels.
    * The goal is to provide an easy property to the template to display the legend of the levels.
@@ -206,19 +219,20 @@ export class GraphComponent implements AfterViewInit, OnChanges, OnInit, OnDestr
    */
   legendItems: LegendItem[];
 
+  destroyed$: Subject<boolean> = new Subject();
+
   constructor() {
     this.utils = ServiceInjector.injector.get(UtilsService);
   }
 
   ngOnInit() {
-    this.subscriptions.push(
-      Observable.fromEvent(window, 'resize').debounceTime(100).subscribe(this.onWindowResize)
-    );
+    Observable.fromEvent(window, 'resize').debounceTime(100).takeUntil(this.destroyed$).subscribe(this.onWindowResize);
     this.setLegendItems();
   }
 
   ngOnDestroy() {
-    this.subscriptions.forEach((subscription: Subscription) => subscription.unsubscribe());
+    this.destroyed$.next(true);
+    this.destroyed$.complete();
   }
 
   ngAfterViewInit() {

--- a/ambari-logsearch-web/src/app/classes/components/graph/time-graph.component.ts
+++ b/ambari-logsearch-web/src/app/classes/components/graph/time-graph.component.ts
@@ -39,6 +39,9 @@ export class TimeGraphComponent extends GraphComponent implements OnInit {
     label: 'filter.timeRange.1hr'
   };
 
+  @Input()
+  timeZone: string = moment.tz.guess();
+
   @Output()
   selectArea: EventEmitter<number[]> = new EventEmitter();
 
@@ -55,8 +58,6 @@ export class TimeGraphComponent extends GraphComponent implements OnInit {
   protected minDragX: number;
 
   protected maxDragX: number;
-
-  protected timeZone: string;
 
   /**
    * This property holds the data structure describing the gaps between the xAxis ticks.
@@ -79,13 +80,8 @@ export class TimeGraphComponent extends GraphComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.subscriptions.push(
-      this.appSettings.getParameter('timeZone').subscribe((value: string): void => {
-        this.timeZone = value;
-        this.createGraph();
-      })
-    );
     super.ngOnInit();
+    this.createGraph();
   }
 
   /**

--- a/ambari-logsearch-web/src/app/classes/components/logs-table/logs-table-component.ts
+++ b/ambari-logsearch-web/src/app/classes/components/logs-table/logs-table-component.ts
@@ -22,6 +22,8 @@ import { ListItem } from '@app/classes/list-item';
 import { ServiceLog } from '@app/classes/models/service-log';
 import { AuditLog } from '@app/classes/models/audit-log';
 
+import * as moment from 'moment-timezone';
+
 export class LogsTableComponent implements OnInit {
   @Input()
   logs: ServiceLog[] | AuditLog[] = [];
@@ -34,6 +36,9 @@ export class LogsTableComponent implements OnInit {
 
   @Input()
   totalCount = 0;
+
+  @Input()
+  timeZone: string = moment.tz.guess();
 
   get displayedColumns(): ListItem[] {
     return this.columns ? this.columns.filter((column: ListItem): boolean => column.isChecked) : [];

--- a/ambari-logsearch-web/src/app/classes/models/store.ts
+++ b/ambari-logsearch-web/src/app/classes/models/store.ts
@@ -37,6 +37,7 @@ import { DataAvaibilityStatesModel } from '@app/modules/app-load/models/data-ava
 import * as auth from '@app/store/reducers/auth.reducers';
 import * as filterHistory from '@app/store/reducers/filter-history.reducers';
 import * as auditLogRepos from '@app/store/reducers/audit-log-repos.reducers';
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
 
 const storeActions = {
     'ARRAY.ADD': 'ADD',
@@ -64,6 +65,7 @@ export interface AppStore {
   graphs: Graph[];
   hosts: NodeItem[];
   userConfigs: UserConfig[];
+  userSettings: userSettings.UserSettingsState;
   clusters: string[];
   components: NodeItem[];
   serviceLogsFields: LogField[];

--- a/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.spec.ts
@@ -61,6 +61,7 @@ import { AuthService } from '@app/services/auth.service';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import { reducer as userSettings } from '@app/store/reducers/user-settings.reducers';
 
 describe('ActionMenuComponent', () => {
   let component: ActionMenuComponent;
@@ -88,7 +89,8 @@ describe('ActionMenuComponent', () => {
           serviceLogsTruncated,
           tabs,
           dataAvailabilityStates,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects)

--- a/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.ts
+++ b/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.ts
@@ -109,7 +109,7 @@ export class ActionMenuComponent  implements OnInit, OnDestroy {
   }
 
   closeLogIndexFilter(): void {
-    this.route.queryParams.first().subscribe((queryParams) => {
+    this.route.queryParams.take(1).subscribe((queryParams) => {
       const {logIndexFilterSettings, ...params} = queryParams;
       this.router.navigate(['.'], {
         queryParams: params,

--- a/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.ts
+++ b/ambari-logsearch-web/src/app/components/action-menu/action-menu.component.ts
@@ -24,7 +24,7 @@ import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { LogsContainerService } from '@app/services/logs-container.service';
-import { UserSettingsService } from '@app/services/user-settings.service';
+import { ServerSettingsService } from '@app/services/server-settings.service';
 import { ListItem } from '@app/classes/list-item';
 import { ClustersService } from '@app/services/storage/clusters.service';
 import { UtilsService } from '@app/services/utils.service';
@@ -63,7 +63,7 @@ export class ActionMenuComponent  implements OnInit, OnDestroy {
 
   constructor(
     private logsContainerService: LogsContainerService,
-    private settings: UserSettingsService,
+    private settings: ServerSettingsService,
     private route: ActivatedRoute,
     private router: Router,
     private clustersService: ClustersService,

--- a/ambari-logsearch-web/src/app/components/app.component.html
+++ b/ambari-logsearch-web/src/app/components/app.component.html
@@ -26,7 +26,10 @@
 <ng-container *ngIf="(authorizationStatus$ | async) !== authorizationStatuses.LOGGED_OUT">
   <data-loading-indicator *ngIf="!(isBaseDataAvailable$ | async) && (isAuthorized$ | async)"></data-loading-indicator>
 
-  <main-container *ngIf="!(isAuthorized$ | async) || (isBaseDataAvailable$ | async)"></main-container>
+  <ng-container *ngIf="!(isAuthorized$ | async) || (isBaseDataAvailable$ | async)">
+    <main-container></main-container>
+    <user-settings></user-settings>
+  </ng-container>
 
   <simple-notifications [options]="notificationServiceOptions"></simple-notifications>
   <div class="request-indicator" [class.open]="httpClient.requestInProgress | async">

--- a/ambari-logsearch-web/src/app/components/app.component.html
+++ b/ambari-logsearch-web/src/app/components/app.component.html
@@ -29,6 +29,7 @@
   <ng-container *ngIf="!(isAuthorized$ | async) || (isBaseDataAvailable$ | async)">
     <main-container></main-container>
     <user-settings></user-settings>
+    <timezone-picker></timezone-picker>
   </ng-container>
 
   <simple-notifications [options]="notificationServiceOptions"></simple-notifications>

--- a/ambari-logsearch-web/src/app/components/audit-logs-entries/audit-logs-entries.component.html
+++ b/ambari-logsearch-web/src/app/components/audit-logs-entries/audit-logs-entries.component.html
@@ -18,7 +18,7 @@
 <tabs [items]="tabs" (tabSwitched)="setActiveTab($event)"></tabs>
 <ng-container [ngSwitch]="activeTab">
   <audit-logs-table *ngSwitchCase="'logs'" [totalCount]="totalCount" [logs]="logs" [columns]="columns"
-    [filtersForm]="filtersForm" [commonFieldNames]="commonFieldNames"></audit-logs-table>
+    [filtersForm]="filtersForm" [commonFieldNames]="commonFieldNames" [timeZone]="timeZone" ></audit-logs-table>
   <div *ngSwitchCase="'summary'" class="row">
     <collapsible-panel commonTitle="{{'logs.topUsers' | translate: usersGraphTitleParams}}" class="col-md-6">
       <horizontal-histogram [data]="topUsersGraphData" [allowFractionalXTicks]="false"

--- a/ambari-logsearch-web/src/app/components/audit-logs-entries/audit-logs-entries.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/audit-logs-entries/audit-logs-entries.component.spec.ts
@@ -52,6 +52,7 @@ import { AuthService } from '@app/services/auth.service';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import { reducer as userSettings } from '@app/store/reducers/user-settings.reducers';
 
 describe('AuditLogsEntriesComponent', () => {
   let component: AuditLogsEntriesComponent;
@@ -80,7 +81,8 @@ describe('AuditLogsEntriesComponent', () => {
           hosts,
           serviceLogsTruncated,
           tabs,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects)

--- a/ambari-logsearch-web/src/app/components/audit-logs-entries/audit-logs-entries.component.ts
+++ b/ambari-logsearch-web/src/app/components/audit-logs-entries/audit-logs-entries.component.ts
@@ -50,6 +50,9 @@ export class AuditLogsEntriesComponent {
   @Input()
   commonFieldNames: string[] = [];
 
+  @Input()
+  timeZone: string;
+
   tabs: LogTypeTab[] = [
     {
       id: 'summary',

--- a/ambari-logsearch-web/src/app/components/audit-logs-table/audit-logs-table.component.html
+++ b/ambari-logsearch-web/src/app/components/audit-logs-table/audit-logs-table.component.html
@@ -23,6 +23,7 @@
         <span class="date-time-format" *ngSwitchCase="'evtTime'">{{value | amTz: timeZone | amDateFormat: timeFormat}}</span>
         <span *ngSwitchCase="'repo'">{{value | repoLabel | async}}</span>
         <span *ngSwitchCase="'type'">{{value | componentLabel | async}}</span>
+        <span *ngSwitchCase="'host'">{{value | hostName | async}}</span>
         <span *ngSwitchDefault class="default-format">{{value || ('common.notAvailable' | translate)}}</span>
       </ng-container>
     </div>

--- a/ambari-logsearch-web/src/app/components/audit-logs-table/audit-logs-table.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/audit-logs-table/audit-logs-table.component.spec.ts
@@ -42,6 +42,7 @@ import {LogsContainerService} from '@app/services/logs-container.service';
 import {UtilsService} from '@app/services/utils.service';
 import {PaginationComponent} from '@app/components/pagination/pagination.component';
 import {DropdownListComponent} from '@modules/shared/components/dropdown-list/dropdown-list.component';
+import {HostNamePipe} from "@app/pipes/host-name.pipe";
 
 import {AuditLogsTableComponent} from './audit-logs-table.component';
 import {ClusterSelectionService} from '@app/services/storage/cluster-selection.service';
@@ -57,10 +58,12 @@ import * as auth from '@app/store/reducers/auth.reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import { reducer as userSettings } from '@app/store/reducers/user-settings.reducers';
 
 import {ComponentLabelPipe} from '@app/pipes/component-label';
 import { RepoLabelPipe } from '@app/pipes/repo-label';
 import { AuditLogFieldLabelPipe } from '@app/pipes/audit-log-field-label.pipe';
+
 
 describe('AuditLogsTableComponent', () => {
   let component: AuditLogsTableComponent;
@@ -74,7 +77,8 @@ describe('AuditLogsTableComponent', () => {
         AuditLogFieldLabelPipe,
         AuditLogsTableComponent,
         PaginationComponent,
-        DropdownListComponent
+        DropdownListComponent,
+        HostNamePipe
       ],
       imports: [
         RouterTestingModule,
@@ -97,7 +101,8 @@ describe('AuditLogsTableComponent', () => {
           clusters,
           components,
           hosts,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects)

--- a/ambari-logsearch-web/src/app/components/audit-logs-table/audit-logs-table.component.ts
+++ b/ambari-logsearch-web/src/app/components/audit-logs-table/audit-logs-table.component.ts
@@ -16,16 +16,17 @@
  * limitations under the License.
  */
 
-import {Component, Input, OnInit, OnDestroy} from '@angular/core';
-import {ListItem} from '@app/classes/list-item';
-import {LogsTableComponent} from '@app/classes/components/logs-table/logs-table-component';
-import {LogsContainerService} from '@app/services/logs-container.service';
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { ListItem } from '@app/classes/list-item';
+import { LogsTableComponent } from '@app/classes/components/logs-table/logs-table-component';
+import { LogsContainerService } from '@app/services/logs-container.service';
 import { Store } from '@ngrx/store';
 import { AppStore } from '@app/classes/models/store';
 import { Observable } from 'rxjs/Observable';
 import { selectAuditLogsFieldState } from '@app/store/selectors/audit-logs-fields.selectors';
 import { LogField, AuditLogsFieldSet } from '@app/classes/object';
 import { Subject } from 'rxjs/Subject';
+
 
 @Component({
   selector: 'audit-logs-table',
@@ -66,11 +67,7 @@ export class AuditLogsTableComponent extends LogsTableComponent implements OnIni
   get filters(): any {
     return this.logsContainer.filters;
   }
-
-  get timeZone(): string {
-    return this.logsContainer.timeZone;
-  }
-
+  
   constructor(
     private logsContainer: LogsContainerService,
     private store: Store<AppStore>

--- a/ambari-logsearch-web/src/app/components/breadrumbs/breadcrumbs.component.ts
+++ b/ambari-logsearch-web/src/app/components/breadrumbs/breadcrumbs.component.ts
@@ -84,19 +84,19 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy {
     return breadcrumbs;
   }
 
-  setPageTite(pageTitle) {
+  setPageTitle(pageTitle) {
     Observable.combineLatest(
       this.translateService.get('common.title'),
       pageTitle ? this.translateService.get(pageTitle) : Observable.of('')
-    ).first().subscribe(([commonTitle, pageTite]) => {
-      this.titleService.setTitle(pageTitle ? `${commonTitle} - ${pageTite}` : commonTitle);
+    ).take(1).subscribe(([commonTitle, pageTitle]) => {
+      this.titleService.setTitle(pageTitle ? `${commonTitle} - ${pageTitle}` : commonTitle);
     });
   }
 
   onNavigationEnd = (): void => {
     this.crumbs = this.getCrumbsFromRouterStateSnapshot(this.router.routerState.snapshot.root);
     if (this.crumbs.length) {
-      this.setPageTite(this.crumbs[this.crumbs.length - 1].text);
+      this.setPageTitle(this.crumbs[this.crumbs.length - 1].text);
     }
   }
 

--- a/ambari-logsearch-web/src/app/components/cluster-filter/cluster-filter.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/cluster-filter/cluster-filter.component.spec.ts
@@ -51,6 +51,7 @@ import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.serv
 import {NotificationService} from '@modules/shared/services/notification.service';
 import {NotificationsService} from 'angular2-notifications/src/notifications.service';
 import { DataAvailabilityStatesStore, dataAvailabilityStates } from '@app/modules/app-load/stores/data-availability-state.store';
+import { reducer as userSettings } from '@app/store/reducers/user-settings.reducers';
 
 import * as auth from '@app/store/reducers/auth.reducers';
 
@@ -87,7 +88,8 @@ describe('ClusterFilterComponent', () => {
           components,
           hosts,
           dataAvailabilityStates,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings
         })
       ],
       providers: [

--- a/ambari-logsearch-web/src/app/components/context-menu/context-menu.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/context-menu/context-menu.component.spec.ts
@@ -55,6 +55,7 @@ import * as auth from '@app/store/reducers/auth.reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import { reducer as userSettings } from '@app/store/reducers/user-settings.reducers';
 
 describe('ContextMenuComponent', () => {
   let component: ContextMenuComponent;
@@ -92,7 +93,8 @@ describe('ContextMenuComponent', () => {
           components,
           serviceLogsTruncated,
           tabs,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects),

--- a/ambari-logsearch-web/src/app/components/date-picker/date-picker.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/date-picker/date-picker.component.spec.ts
@@ -16,12 +16,19 @@
  * limitations under the License.
  */
 
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {StoreModule} from '@ngrx/store';
-import * as moment from 'moment-timezone';
-import {AppSettingsService, appSettings} from '@app/services/storage/app-settings.service';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockHttpRequestModules } from '@app/test-config.spec';
 
-import {DatePickerComponent} from './date-picker.component';
+import { StoreModule } from '@ngrx/store';
+import * as moment from 'moment-timezone';
+import { AppSettingsService, appSettings } from '@app/services/storage/app-settings.service';
+
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
+import { EffectsModule } from '@ngrx/effects';
+import { UserSettingsEffects } from '@app/store/effects/user-settings.effects';
+import { UserSettingsService } from '@app/services/user-settings.service';
+
+import { DatePickerComponent } from './date-picker.component';
 
 describe('DatePickerComponent', () => {
   let component: DatePickerComponent;
@@ -32,10 +39,14 @@ describe('DatePickerComponent', () => {
       declarations: [DatePickerComponent],
       imports: [
         StoreModule.provideStore({
-          appSettings
+          appSettings,
+          userSettings: userSettings.reducer
         })
       ],
-      providers: [AppSettingsService]
+      providers: [
+        AppSettingsService,
+        UserSettingsService
+      ]
     })
     .compileComponents();
   }));

--- a/ambari-logsearch-web/src/app/components/date-picker/date-picker.component.ts
+++ b/ambari-logsearch-web/src/app/components/date-picker/date-picker.component.ts
@@ -22,37 +22,18 @@ import {
 import * as $ from 'jquery';
 import * as moment from 'moment';
 import '@vendor/js/bootstrap-datetimepicker.min';
-import {AppSettingsService} from '@app/services/storage/app-settings.service';
 
+import { Subject } from 'rxjs/Subject';
+import { Observable } from 'rxjs/Observable';
+import { Store } from '@ngrx/store';
+import { AppStore } from '@app/classes/models/store';
+import { selectTimeZone } from '@app/store/selectors/user-settings.selectors';
+import { SetUserSettingsAction } from '@app/store/actions/user-settings.actions';
 @Component({
   selector: 'date-picker',
   templateUrl: './date-picker.component.html'
 })
 export class DatePickerComponent implements OnInit, OnChanges, OnDestroy {
-
-  constructor(private appSettings: AppSettingsService) {
-  }
-
-  ngOnInit(): void {
-    this.appSettings.getParameter('timeZone').subscribe((value: string): void => {
-      this.destroyDatePicker();
-      this.timeZone = value;
-      if (this.datePickerElement) {
-        this.createDatePicker();
-      }
-    });
-    this.createDatePicker();
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.hasOwnProperty('time') && this.datePickerElement) {
-      this.setTime(changes.time.currentValue);
-    }
-  }
-
-  ngOnDestroy(): void {
-    this.destroyDatePicker();
-  }
 
   /**
    * Value of time input field passed from parent component
@@ -71,6 +52,46 @@ export class DatePickerComponent implements OnInit, OnChanges, OnDestroy {
 
   private timeZone: string;
 
+  /**
+   * Set value to time input field
+   * @param {Moment|Date|string} time
+   */
+  private setTime(time: moment.Moment | Date | string): void {
+    const timeMoment = moment.isMoment(time) ? time : moment(time);
+    this.datePickerElement.data('DateTimePicker').date(timeMoment);
+  }
+
+  timeZone$: Observable<string> = this.store.select(selectTimeZone);
+
+  destroyed$: Subject<boolean> = new Subject();
+
+  constructor( private store: Store<AppStore> ) {}
+
+  ngOnInit(): void {
+    this.timeZone$.takeUntil(this.destroyed$).subscribe(this.onTimeZoneSettingsChange);
+    this.createDatePicker();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.hasOwnProperty('time') && this.datePickerElement) {
+      this.setTime(changes.time.currentValue);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroyDatePicker();
+    this.destroyed$.next(true);
+    this.destroyed$.complete();
+  }
+
+  onTimeZoneSettingsChange = (timeZone: string): void => {
+    this.destroyDatePicker();
+    this.timeZone = timeZone;
+    if (this.datePickerElement) {
+      this.createDatePicker();
+    }
+  }
+
   private createDatePicker(): void {
     this.datePickerElement = $(this.datePicker.nativeElement);
     this.datePickerElement.datetimepicker({
@@ -85,15 +106,6 @@ export class DatePickerComponent implements OnInit, OnChanges, OnDestroy {
     if (datePicker) {
       datePicker.data('DateTimePicker').destroy();
     }
-  }
-
-  /**
-   * Set value to time input field
-   * @param {Moment|Date|string} time
-   */
-  private setTime(time: moment.Moment | Date | string): void {
-    const timeMoment = moment.isMoment(time) ? time : moment(time);
-    this.datePickerElement.data('DateTimePicker').date(timeMoment);
   }
 
 }

--- a/ambari-logsearch-web/src/app/components/date-picker/date-picker.component.ts
+++ b/ambari-logsearch-web/src/app/components/date-picker/date-picker.component.ts
@@ -52,15 +52,6 @@ export class DatePickerComponent implements OnInit, OnChanges, OnDestroy {
 
   private timeZone: string;
 
-  /**
-   * Set value to time input field
-   * @param {Moment|Date|string} time
-   */
-  private setTime(time: moment.Moment | Date | string): void {
-    const timeMoment = moment.isMoment(time) ? time : moment(time);
-    this.datePickerElement.data('DateTimePicker').date(timeMoment);
-  }
-
   timeZone$: Observable<string> = this.store.select(selectTimeZone);
 
   destroyed$: Subject<boolean> = new Subject();
@@ -82,6 +73,15 @@ export class DatePickerComponent implements OnInit, OnChanges, OnDestroy {
     this.destroyDatePicker();
     this.destroyed$.next(true);
     this.destroyed$.complete();
+  }
+
+  /**
+   * Set value to time input field
+   * @param {Moment|Date|string} time
+   */
+  private setTime(time: moment.Moment | Date | string): void {
+    const timeMoment = moment.isMoment(time) ? time : moment(time);
+    this.datePickerElement.data('DateTimePicker').date(timeMoment);
   }
 
   onTimeZoneSettingsChange = (timeZone: string): void => {

--- a/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.html
+++ b/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.html
@@ -23,7 +23,9 @@
                 defaultParameterName="log_message"></search-box>
     <time-range-picker *ngIf="isFilterConditionDisplayed('timeRange')" formControlName="timeRange"
                        class="filter-input"></time-range-picker>
-    <timezone-picker class="filter-input"></timezone-picker>
+    <button class="btn btn-link time-zone-picker-btn" (click)="openTimeZonePicker()">
+      {{(timeZone$ | async) | timeZoneAbbr}} <span class="caret"></span>
+    </button>
     <button class="btn btn-success search-button" type="button" (click)="onSearchBtnClick()">
       <span class="fa fa-search"></span>
     </button>

--- a/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.less
+++ b/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.less
@@ -66,10 +66,9 @@
       margin-right: -1 * (@input-border-width);
     }
 
-    time-range-picker {
-      /deep/ .dropdown-menu {
-        left: @col-padding;
-      }
+    .time-zone-picker-btn {
+      border: @input-border;
+      height: 100%;
     }
   }
 

--- a/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.spec.ts
@@ -38,6 +38,7 @@ import {ServiceLogsTruncatedService, serviceLogsTruncated} from '@app/services/s
 import {TabsService, tabs} from '@app/services/storage/tabs.service';
 import {UtilsService} from '@app/services/utils.service';
 import {LogsContainerService} from '@app/services/logs-container.service';
+import { TimeZoneAbbrPipe } from '@app/pipes/timezone-abbr.pipe';
 
 import {FiltersPanelComponent} from './filters-panel.component';
 import {ClusterSelectionService} from '@app/services/storage/cluster-selection.service';
@@ -53,6 +54,7 @@ import { AuthService } from '@app/services/auth.service';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import { reducer as userSettings } from '@app/store/reducers/user-settings.reducers';
 
 describe('FiltersPanelComponent', () => {
   let component: FiltersPanelComponent;
@@ -69,7 +71,8 @@ describe('FiltersPanelComponent', () => {
     };
     TestBed.configureTestingModule({
       declarations: [
-        FiltersPanelComponent
+        FiltersPanelComponent,
+        TimeZoneAbbrPipe
       ],
       imports: [
         RouterTestingModule,
@@ -87,7 +90,8 @@ describe('FiltersPanelComponent', () => {
           appState,
           serviceLogsTruncated,
           tabs,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects),

--- a/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.ts
+++ b/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.ts
@@ -16,20 +16,26 @@
  * limitations under the License.
  */
 
-import {Component, OnDestroy, Input, ViewContainerRef, OnInit, Output, EventEmitter} from '@angular/core';
-import {FormGroup} from '@angular/forms';
-import {Observable} from 'rxjs/Observable';
-import {Subject} from 'rxjs/Subject';
+import { Component, OnDestroy, Input, ViewContainerRef, OnInit, Output, EventEmitter } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/operator/defaultIfEmpty';
-import {FilterCondition, SearchBoxParameter, SearchBoxParameterTriggered} from '@app/classes/filtering';
-import {ListItem} from '@app/classes/list-item';
-import {HomogeneousObject} from '@app/classes/object';
-import {LogsType} from '@app/classes/string';
-import {LogsContainerService} from '@app/services/logs-container.service';
-import {UtilsService} from '@app/services/utils.service';
-import {AppStateService} from '@app/services/storage/app-state.service';
-import {Subscription} from 'rxjs/Subscription';
+import { FilterCondition, SearchBoxParameter, SearchBoxParameterTriggered } from '@app/classes/filtering';
+import { ListItem } from '@app/classes/list-item';
+import { HomogeneousObject } from '@app/classes/object';
+import { LogsType } from '@app/classes/string';
+import { LogsContainerService } from '@app/services/logs-container.service';
+import { UtilsService } from '@app/services/utils.service';
+import { AppStateService } from '@app/services/storage/app-state.service';
+import { Subscription } from 'rxjs/Subscription';
+import { Router, ActivatedRoute } from '@angular/router';
+
+import { Store } from '@ngrx/store';
+import { AppStore } from '@app/classes/models/store';
+import { selectTimeZone } from '@app/store/selectors/user-settings.selectors';
+import * as moment from 'moment-timezone';
 
 @Component({
   selector: 'filters-panel',
@@ -52,6 +58,9 @@ export class FiltersPanelComponent implements OnDestroy, OnInit {
   searchBoxItems$: Observable<ListItem[]>;
 
   searchBoxValueUpdate: Subject<void> = new Subject();
+
+  timeZone$: Observable<string> = this.store.select(selectTimeZone).startWith(moment.tz.guess());
+
 
   private isServiceLogsFileView$: Observable<boolean> = this.appState.getParameter('isServiceLogsFileView');
 
@@ -87,8 +96,15 @@ export class FiltersPanelComponent implements OnDestroy, OnInit {
     return this.logsContainerService.queryParameterAdd;
   }
 
-  constructor(private logsContainerService: LogsContainerService, public viewContainerRef: ViewContainerRef,
-              private utils: UtilsService, private appState: AppStateService) {
+  constructor(
+    private logsContainerService: LogsContainerService,
+    public viewContainerRef: ViewContainerRef,
+    private utils: UtilsService,
+    private appState: AppStateService,
+    private router: Router,
+    private route: ActivatedRoute,
+    private store: Store<AppStore>
+  ) {
   }
 
   ngOnInit() {
@@ -151,6 +167,14 @@ export class FiltersPanelComponent implements OnDestroy, OnInit {
   onSearchBtnClick(): void {
     this.updateSearchBoxValue();
     this.submit.emit(this.filtersForm.getRawValue());
+  }
+
+  openTimeZonePicker() {
+    this.router.navigate(['.'], {
+      queryParamsHandling: 'merge',
+      queryParams: {timeZoneSettings: 'show'},
+      relativeTo: this.route.root.firstChild
+    });
   }
 
 }

--- a/ambari-logsearch-web/src/app/components/log-context/log-context.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/log-context/log-context.component.spec.ts
@@ -52,6 +52,7 @@ import { AuthService } from '@app/services/auth.service';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import { reducer as userSettings } from '@app/store/reducers/user-settings.reducers';
 
 describe('LogContextComponent', () => {
   let component: LogContextComponent;
@@ -79,7 +80,8 @@ describe('LogContextComponent', () => {
           hosts,
           serviceLogsTruncated,
           tabs,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects),

--- a/ambari-logsearch-web/src/app/components/log-index-filter/log-index-filter.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/log-index-filter/log-index-filter.component.spec.ts
@@ -38,7 +38,7 @@ import {ServiceLogsTruncatedService, serviceLogsTruncated} from '@app/services/s
 import {TabsService, tabs} from '@app/services/storage/tabs.service';
 import {ComponentGeneratorService} from '@app/services/component-generator.service';
 import {LogsContainerService} from '@app/services/logs-container.service';
-import {UserSettingsService} from '@app/services/user-settings.service';
+import {ServerSettingsService} from '@app/services/server-settings.service';
 import {UtilsService} from '@app/services/utils.service';
 import {DropdownButtonComponent} from '@modules/shared/components/dropdown-button/dropdown-button.component';
 import {DropdownListComponent} from '@modules/shared/components/dropdown-list/dropdown-list.component';
@@ -101,7 +101,7 @@ describe('LogIndexFilterComponent', () => {
         ...MockHttpRequestModules,
         ComponentGeneratorService,
         LogsContainerService,
-        UserSettingsService,
+        ServerSettingsService,
         UtilsService,
         AuditLogsService,
         ServiceLogsService,

--- a/ambari-logsearch-web/src/app/components/log-index-filter/log-index-filter.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/log-index-filter/log-index-filter.component.spec.ts
@@ -60,6 +60,7 @@ import { AuthService } from '@app/services/auth.service';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import { reducer as userSettings } from '@app/store/reducers/user-settings.reducers';
 
 describe('LogIndexFilterComponent', () => {
   let component: LogIndexFilterComponent;
@@ -86,7 +87,8 @@ describe('LogIndexFilterComponent', () => {
           serviceLogsTruncated,
           tabs,
           dataAvailabilityStates,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects)

--- a/ambari-logsearch-web/src/app/components/log-index-filter/log-index-filter.component.ts
+++ b/ambari-logsearch-web/src/app/components/log-index-filter/log-index-filter.component.ts
@@ -28,7 +28,7 @@ import { HomogeneousObject, LogLevelObject } from '@app/classes/object';
 import { LogIndexFilterComponentConfig } from '@app/classes/settings';
 import { LogLevel } from '@app/classes/string';
 import { LogsContainerService } from '@app/services/logs-container.service';
-import { UserSettingsService } from '@app/services/user-settings.service';
+import { ServerSettingsService } from '@app/services/server-settings.service';
 import { UtilsService } from '@app/services/utils.service';
 import { ClustersService } from '@app/services/storage/clusters.service';
 import { HostsService } from '@app/services/storage/hosts.service';
@@ -85,7 +85,7 @@ export class LogIndexFilterComponent implements OnInit, OnDestroy, OnChanges, Co
 
   constructor(
     private logsContainer: LogsContainerService,
-    private settingsService: UserSettingsService,
+    private settingsService: ServerSettingsService,
     private utils: UtilsService,
     private clustersStorage: ClustersService,
     private hostsStorage: HostsService,

--- a/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.html
+++ b/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.html
@@ -46,10 +46,9 @@
         <time-histogram (selectArea)="setCustomTimeRange($event[0], $event[1])" [data]="serviceLogsHistogramData"
           [colors]="serviceLogsHistogramColors" [allowFractionalYTicks]="false" [timeZone]="timeZone$ | async"
           svgId="service-logs-histogram" [class.loading]="logsContainerService.isGraphRequestInProgress$ | async"></time-histogram>
-          {{timeZone$ | async}}
       </collapsible-panel>
       <service-logs-table [totalCount]="totalCount" [logs]="serviceLogs | async" [columns]="serviceLogsColumns | async"
-        [filtersForm]="filtersForm" [class.loading]="logsContainerService.isLogsRequestInProgress$ | async"></service-logs-table>
+        [filtersForm]="filtersForm" [class.loading]="logsContainerService.isLogsRequestInProgress$ | async" [timeZone]="timeZone$ | async"></service-logs-table>
     </ng-container>
     <ng-container *ngSwitchCase="'auditLogs'">
       <collapsible-panel commonTitle="logs.duration" openTitle="logs.hideGraph" collapsedTitle="logs.showGraph">

--- a/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.html
+++ b/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.html
@@ -42,18 +42,19 @@
     <ng-container *ngSwitchCase="'serviceLogs'">
       <collapsible-panel [class.hide]="isServiceLogsFileView$ | async" openTitle="logs.hideGraph" collapsedTitle="logs.showGraph" class="service-logs-histogram">
         <header>{{(!totalEventsFoundMessageParams.totalCount ? 'logs.noEventFound' :
-            (totalEventsFoundMessageParams.totalCount === 1 ? 'logs.oneEventFound' : 'logs.totalEventFound')) | translate: totalEventsFoundMessageParams}}</header>
+          (totalEventsFoundMessageParams.totalCount === 1 ? 'logs.oneEventFound' : 'logs.totalEventFound')) | translate: totalEventsFoundMessageParams}}</header>
         <time-histogram (selectArea)="setCustomTimeRange($event[0], $event[1])" [data]="serviceLogsHistogramData"
-                        [colors]="serviceLogsHistogramColors" [allowFractionalYTicks]="false"
-                        svgId="service-logs-histogram" [class.loading]="logsContainerService.isGraphRequestInProgress$ | async"></time-histogram>
+          [colors]="serviceLogsHistogramColors" [allowFractionalYTicks]="false" [timeZone]="timeZone$ | async"
+          svgId="service-logs-histogram" [class.loading]="logsContainerService.isGraphRequestInProgress$ | async"></time-histogram>
+          {{timeZone$ | async}}
       </collapsible-panel>
       <service-logs-table [totalCount]="totalCount" [logs]="serviceLogs | async" [columns]="serviceLogsColumns | async"
-                          [filtersForm]="filtersForm" [class.loading]="logsContainerService.isLogsRequestInProgress$ | async"></service-logs-table>
+        [filtersForm]="filtersForm" [class.loading]="logsContainerService.isLogsRequestInProgress$ | async"></service-logs-table>
     </ng-container>
     <ng-container *ngSwitchCase="'auditLogs'">
       <collapsible-panel commonTitle="logs.duration" openTitle="logs.hideGraph" collapsedTitle="logs.showGraph">
         <time-line-graph (selectArea)="setCustomTimeRange($event[0], $event[1])" [data]="auditLogsGraphData"
-          [allowFractionalYTicks]="false" [skipZeroValuesInTooltip]="false" svgId="audit-logs-graph"
+          [allowFractionalYTicks]="false" [skipZeroValuesInTooltip]="false" svgId="audit-logs-graph" [timeZone]="timeZone$ | async"
           [class.loading]="logsContainerService.isGraphRequestInProgress$ | async"></time-line-graph>
       </collapsible-panel>
       <audit-logs-entries [totalCount]="totalCount" [logs]="auditLogs | async" [columns]="auditLogsColumns | async" [commonFieldNames]="auditLogsCommonFieldNames"

--- a/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/logs-container/logs-container.component.spec.ts
@@ -51,10 +51,13 @@ import {NotificationsService} from 'angular2-notifications/src/notifications.ser
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 
 import * as auth from '@app/store/reducers/auth.reducers';
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
 import { AuthService } from '@app/services/auth.service';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
+import { UserSettingsEffects } from '@app/store/effects/user-settings.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import { UserSettingsService } from '@app/services/user-settings.service';
 
 describe('LogsContainerComponent', () => {
   let component: LogsContainerComponent;
@@ -82,9 +85,11 @@ describe('LogsContainerComponent', () => {
           tabs,
           hosts,
           serviceLogsTruncated,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings: userSettings.reducer
         }),
         EffectsModule.run(AuthEffects),
+        EffectsModule.run(UserSettingsEffects),
         EffectsModule.run(NotificationEffects),
         ...TranslationModules,
         TooltipModule.forRoot(),
@@ -112,7 +117,8 @@ describe('LogsContainerComponent', () => {
         NotificationsService,
         NotificationService,
         LogsStateService,
-        AuthService
+        AuthService,
+        UserSettingsService
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })

--- a/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.html
+++ b/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.html
@@ -149,6 +149,10 @@
                 <label *ngIf="showLabels">{{getLabelForField('path') | translate}}</label>
                 {{log.path}}
               </div>
+              <div *ngIf="isColumnDisplayed('host')" [ngClass]="'log-host'" [title]="log.host">
+                <label *ngIf="showLabels">{{getLabelForField('host') | translate}}</label>
+                {{log.host | hostName}}
+              </div>
               <ng-container *ngFor="let column of displayedColumns">
                 <div *ngIf="customStyledColumns.indexOf(column.value) === -1" [ngClass]="'log-' + (column.value | lowercase)"
                      [title]="(log[column.value] || '')">

--- a/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.html
+++ b/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.html
@@ -90,7 +90,7 @@
             <tr class="log-item-row">
               <td class="log-action">
                 <dropdown-button iconClass="fa fa-ellipsis-v action" [hideCaret]="true" [options]="logActions"
-                                 [listItemArguments]="[log]" [showSelectedValue]="false"></dropdown-button>
+                  [listItemArguments]="[log]" [showSelectedValue]="false"></dropdown-button>
               </td>
               <td *ngIf="isColumnDisplayed('logtime')" class="log-time">
                 <time>

--- a/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.html
+++ b/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.html
@@ -59,6 +59,7 @@
           <col *ngIf="isColumnDisplayed('logtime')" class="log-time">
           <col *ngIf="isColumnDisplayed('level')" class="log-level">
           <col *ngIf="isColumnDisplayed('type')" class="log-type">
+          <col *ngIf="isColumnDisplayed('host')" class="col-default-fixed log-host">
           <ng-container *ngFor="let column of displayedColumns">
             <col *ngIf="customStyledColumns.indexOf(column.value) === -1" [ngClass]="'col-default-fixed log-' + column.value">
           </ng-container>
@@ -71,6 +72,7 @@
             <th *ngIf="isColumnDisplayed('logtime')">{{getLabelForField('logtime') | translate}}</th>
             <th *ngIf="isColumnDisplayed('level')">{{getLabelForField('level') | translate}}</th>
             <th *ngIf="isColumnDisplayed('type')">{{getLabelForField('type') | translate}}</th>
+            <th *ngIf="isColumnDisplayed('host')">{{getLabelForField('host') | translate}}</th>
             <ng-container *ngFor="let column of displayedColumns">
               <th *ngIf="customStyledColumns.indexOf(column.value) === -1">{{getLabelForField(column.value) | translate}}</th>
             </ng-container>
@@ -100,6 +102,9 @@
               </td>
               <td *ngIf="isColumnDisplayed('type')" [ngClass]="'log-type'">
                 {{log.type | componentLabel | async}}
+              </td>
+              <td *ngIf="isColumnDisplayed('host')" [ngClass]="'log-host'">
+                {{log.host | hostName | async}}
               </td>
               <ng-container *ngFor="let column of displayedColumns">
                 <td *ngIf="customStyledColumns.indexOf(column.value) === -1"
@@ -151,7 +156,7 @@
               </div>
               <div *ngIf="isColumnDisplayed('host')" [ngClass]="'log-host'" [title]="log.host">
                 <label *ngIf="showLabels">{{getLabelForField('host') | translate}}</label>
-                {{log.host | hostName}}
+                {{log.host | hostName | async}}
               </div>
               <ng-container *ngFor="let column of displayedColumns">
                 <div *ngIf="customStyledColumns.indexOf(column.value) === -1" [ngClass]="'log-' + (column.value | lowercase)"

--- a/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.spec.ts
@@ -48,6 +48,7 @@ import {DropdownListComponent} from '@modules/shared/components/dropdown-list/dr
 
 import {ServiceLogsTableComponent, ListLayout} from './service-logs-table.component';
 import {ComponentLabelPipe} from "@app/pipes/component-label";
+import {HostNamePipe} from "@app/pipes/host-name.pipe";
 import {ClusterSelectionService} from '@app/services/storage/cluster-selection.service';
 import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
@@ -71,7 +72,8 @@ describe('ServiceLogsTableComponent', () => {
         ServiceLogsTableComponent,
         PaginationComponent,
         DropdownListComponent,
-        ComponentLabelPipe
+        ComponentLabelPipe,
+        HostNamePipe
       ],
       imports: [
         RouterTestingModule,

--- a/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.spec.ts
@@ -61,6 +61,7 @@ import * as auth from '@app/store/reducers/auth.reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import { reducer as userSettings } from '@app/store/reducers/user-settings.reducers';
 
 describe('ServiceLogsTableComponent', () => {
   let component: ServiceLogsTableComponent;
@@ -96,7 +97,8 @@ describe('ServiceLogsTableComponent', () => {
           clusters,
           components,
           hosts,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects),

--- a/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.ts
+++ b/ambari-logsearch-web/src/app/components/service-logs-table/service-logs-table.component.ts
@@ -111,7 +111,7 @@ export class ServiceLogsTableComponent extends LogsTableComponent implements Aft
 
   readonly timeFormat = 'h:mm:ss A';
 
-  readonly customStyledColumns: string[] = ['level', 'type', 'logtime', 'log_message', 'path'];
+  readonly customStyledColumns: string[] = ['level', 'type', 'logtime', 'log_message', 'path', 'host'];
 
   private readonly messageFilterParameterName = 'log_message';
 
@@ -129,11 +129,7 @@ export class ServiceLogsTableComponent extends LogsTableComponent implements Aft
   get contextMenuItems(): ListItem[] {
     return this.logsContainer.queryContextMenuItems;
   }
-
-  get timeZone(): string {
-    return this.logsContainer.timeZone;
-  }
-
+  
   get filters(): any {
     return this.logsContainer.filters;
   }

--- a/ambari-logsearch-web/src/app/components/tabs/tabs.component.ts
+++ b/ambari-logsearch-web/src/app/components/tabs/tabs.component.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {LogTypeTab} from '@app/classes/models/log-type-tab';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { LogTypeTab } from '@app/classes/models/log-type-tab';
 import { LogsFilteringUtilsService } from '@app/services/logs-filtering-utils.service';
 
 export enum TabsSwitchMode {

--- a/ambari-logsearch-web/src/app/components/time-range-picker/time-range-picker.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/time-range-picker/time-range-picker.component.spec.ts
@@ -53,6 +53,7 @@ import { AuthService } from '@app/services/auth.service';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
 
 describe('TimeRangePickerComponent', () => {
   let component: TimeRangePickerComponent;
@@ -77,7 +78,8 @@ describe('TimeRangePickerComponent', () => {
           serviceLogsHistogramData,
           serviceLogsTruncated,
           tabs,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings: userSettings.reducer
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects),

--- a/ambari-logsearch-web/src/app/components/timezone-picker/timezone-picker.component.html
+++ b/ambari-logsearch-web/src/app/components/timezone-picker/timezone-picker.component.html
@@ -16,7 +16,7 @@
 -->
 
 <button class="btn btn-link" (click)="setTimeZonePickerDisplay(true)">
-  {{timeZone | timeZoneAbbr}} <span class="caret"></span>
+  {{(timeZone$ | async) | timeZoneAbbr}} <span class="caret"></span>
 </button>
 <modal *ngIf="isTimeZonePickerDisplayed" [showCloseButton]="false" [isLargeModal]="true"
        (init)="initMap()" (cancel)="setTimeZonePickerDisplay(false)" (submit)="setTimeZone()">

--- a/ambari-logsearch-web/src/app/components/timezone-picker/timezone-picker.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/timezone-picker/timezone-picker.component.spec.ts
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {StoreModule} from '@ngrx/store';
 import {AppSettingsService, appSettings} from '@app/services/storage/app-settings.service';
@@ -126,6 +127,7 @@ describe('TimeZonePickerComponent', () => {
         DataAvailabilityStatesStore,
         UserSettingsService
       ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();
   }));

--- a/ambari-logsearch-web/src/app/components/timezone-picker/timezone-picker.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/timezone-picker/timezone-picker.component.spec.ts
@@ -35,7 +35,7 @@ import {ServiceLogsTruncatedService, serviceLogsTruncated} from '@app/services/s
 import {TabsService, tabs} from '@app/services/storage/tabs.service';
 import {HttpClientService} from '@app/services/http-client.service';
 import {LogsContainerService} from '@app/services/logs-container.service';
-import {UserSettingsService} from '@app/services/user-settings.service';
+import {ServerSettingsService} from '@app/services/server-settings.service';
 import {UtilsService} from '@app/services/utils.service';
 import {AuthService} from '@app/services/auth.service';
 import {TimeZoneAbbrPipe} from '@app/pipes/timezone-abbr.pipe';
@@ -55,9 +55,12 @@ import {NotificationService} from '@modules/shared/services/notification.service
 import { dataAvailabilityStates, DataAvailabilityStatesStore } from '@app/modules/app-load/stores/data-availability-state.store';
 
 import * as auth from '@app/store/reducers/auth.reducers';
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
+import { UserSettingsEffects } from '@app/store/effects/user-settings.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import { UserSettingsService } from '@app/services/user-settings.service';
 
 describe('TimeZonePickerComponent', () => {
   let component: TimeZonePickerComponent;
@@ -87,9 +90,11 @@ describe('TimeZonePickerComponent', () => {
           serviceLogsTruncated,
           tabs,
           dataAvailabilityStates,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings: userSettings.reducer
         }),
         EffectsModule.run(AuthEffects),
+        EffectsModule.run(UserSettingsEffects),
         EffectsModule.run(NotificationEffects),
         ...TranslationModules
       ],
@@ -110,7 +115,7 @@ describe('TimeZonePickerComponent', () => {
         TabsService,
         LogsContainerService,
         AuthService,
-        UserSettingsService,
+        ServerSettingsService,
         UtilsService,
         ClusterSelectionService,
         RoutingUtilsService,
@@ -118,7 +123,8 @@ describe('TimeZonePickerComponent', () => {
         LogsStateService,
         NotificationsService,
         NotificationService,
-        DataAvailabilityStatesStore
+        DataAvailabilityStatesStore,
+        UserSettingsService
       ],
     })
     .compileComponents();

--- a/ambari-logsearch-web/src/app/components/top-menu/top-menu.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/top-menu/top-menu.component.spec.ts
@@ -54,6 +54,7 @@ import * as auth from '@app/store/reducers/auth.reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
 
 describe('TopMenuComponent', () => {
   let component: TopMenuComponent;
@@ -78,7 +79,8 @@ describe('TopMenuComponent', () => {
           clusters,
           components,
           hosts,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings: userSettings.reducer
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects),

--- a/ambari-logsearch-web/src/app/components/top-menu/top-menu.component.ts
+++ b/ambari-logsearch-web/src/app/components/top-menu/top-menu.component.ts
@@ -16,13 +16,13 @@
  * limitations under the License.
  */
 
-import {Component} from '@angular/core';
-import {FormGroup} from '@angular/forms';
-import {FilterCondition, TimeUnitListItem} from '@app/classes/filtering';
-import {ListItem} from '@app/classes/list-item';
-import {HomogeneousObject} from '@app/classes/object';
-import {LogsContainerService} from '@app/services/logs-container.service';
-import {Router} from '@angular/router';
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FilterCondition, TimeUnitListItem } from '@app/classes/filtering';
+import { ListItem } from '@app/classes/list-item';
+import { HomogeneousObject } from '@app/classes/object';
+import { LogsContainerService } from '@app/services/logs-container.service';
+import { Router, ActivatedRoute } from '@angular/router';
 
 import { Store } from '@ngrx/store';
 import { AppStore } from '@app/classes/models/store';
@@ -38,6 +38,7 @@ export class TopMenuComponent {
   constructor(
     private logsContainer: LogsContainerService,
     private router: Router,
+    private route: ActivatedRoute,
     private store: Store<AppStore>
   ) {}
 
@@ -49,8 +50,14 @@ export class TopMenuComponent {
     return this.logsContainer.filters;
   };
 
-  openSettings = (): void => {};
-
+  openUserSettingsModal = (): void => {
+    this.router.navigate(['.'], {
+      queryParamsHandling: 'merge',
+      queryParams: {showUserSettings: 'show'},
+      relativeTo: this.route.root.firstChild
+    });
+  }
+  
   /**
    * Dispatch the LogOutAction.
    */
@@ -70,7 +77,7 @@ export class TopMenuComponent {
       subItems: [
         {
           label: 'common.settings',
-          onSelect: this.openSettings,
+          onSelect: this.openUserSettingsModal,
           iconClass: 'fa fa-cog'
         },
 

--- a/ambari-logsearch-web/src/app/modules/shared/components/dropdown-list/dropdown-list.component.spec.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/components/dropdown-list/dropdown-list.component.spec.ts
@@ -53,6 +53,7 @@ import * as auth from '@app/store/reducers/auth.reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
 
 describe('DropdownListComponent', () => {
   let component: DropdownListComponent;
@@ -86,7 +87,8 @@ describe('DropdownListComponent', () => {
           components,
           serviceLogsTruncated,
           tabs,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings: userSettings.reducer
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects),

--- a/ambari-logsearch-web/src/app/modules/shared/components/filter-dropdown/filter-dropdown.component.spec.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/components/filter-dropdown/filter-dropdown.component.spec.ts
@@ -51,6 +51,7 @@ import * as auth from '@app/store/reducers/auth.reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
 
 describe('FilterDropdownComponent', () => {
   let component: FilterDropdownComponent;
@@ -99,7 +100,8 @@ describe('FilterDropdownComponent', () => {
           clusters,
           components,
           hosts,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings: userSettings.reducer
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects),

--- a/ambari-logsearch-web/src/app/modules/shared/components/modal-dialog/modal-dialog.component.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/components/modal-dialog/modal-dialog.component.ts
@@ -53,6 +53,9 @@ export class ModalDialogComponent implements AfterViewInit {
 
   @Output()
   onCloseRequest: EventEmitter<MouseEvent> =  new EventEmitter();
+  
+  @Output()
+  onAfterViewInit: EventEmitter<ModalDialogComponent> =  new EventEmitter();
 
   @ViewChild('header')
   headerElementRef: ElementRef;
@@ -79,6 +82,9 @@ export class ModalDialogComponent implements AfterViewInit {
     );
     this.showFooter = this.footerElementRef && this.footerElementRef.nativeElement.children.length;
     this.cdRef.detectChanges();
+    if (this.onAfterViewInit) {
+      this.onAfterViewInit.emit(this);
+    }
   }
 
   onCloseBtnClick(event: MouseEvent) {

--- a/ambari-logsearch-web/src/app/modules/shared/components/time-zone-map-input/time-zone-map-input.component.html
+++ b/ambari-logsearch-web/src/app/modules/shared/components/time-zone-map-input/time-zone-map-input.component.html
@@ -14,17 +14,4 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-
-<modal-dialog [visible]="visible$ | async"
-  [showCloseBtn]="true"
-  (onCloseRequest)="onCloseRequest($event)"
-  (onAfterViewInit)="initMap()"
-  class="time-zone-modal">
-  <time-zone-map-input [value]="timeZone$ | async" (onChange)="onTimeZoneSelect($event)" [mapElementId]="mapElementId"></time-zone-map-input>
-  <footer>
-    <button class="btn btn-secondary" (click)="onCloseRequest($event)">{{'modal.cancel' | translate}}</button>
-    <button class="btn btn-primary" (click)="onSaveRequest($event)">
-      {{'modal.save' | translate}}
-    </button>
-  </footer>
-</modal-dialog>
+<div attr.id="{{mapElementId}}" class="time-zone-input"></div>

--- a/ambari-logsearch-web/src/app/modules/shared/components/time-zone-map-input/time-zone-map-input.component.less
+++ b/ambari-logsearch-web/src/app/modules/shared/components/time-zone-map-input/time-zone-map-input.component.less
@@ -29,6 +29,7 @@
      }
      > div {
       display: flex;
+      flex-wrap: wrap;
       justify-content: flex-end;
      }
    }

--- a/ambari-logsearch-web/src/app/modules/shared/components/time-zone-map-input/time-zone-map-input.component.less
+++ b/ambari-logsearch-web/src/app/modules/shared/components/time-zone-map-input/time-zone-map-input.component.less
@@ -16,40 +16,20 @@
  * limitations under the License.
  */
 
-@import '../../modules/shared/variables';
-
-:host {
-  .btn-link {
-    // TODO implement actual colors
-    color: @submit-color;
-
-    &:hover {
-      color: @submit-hover-color;
-    }
-  }
-
-  /deep/ #timezone-map {
-    .Cbox {
-      position: sticky;
-      top: 0;
-      .quickLink {
-        padding-top: 4px;
-      }
-    }
-
-    .hoverZone {
-      display: inline-block;
-
-      &:after {
-        content: '\007C\00a0\00a0';
-        visibility: hidden;
-      }
-    }
-  }
-
-  /deep/ modal-dialog.time-zone-modal .modal-dialog {
-    width: 1024px;
-    max-width: 75vw;
-  }
-
-}
+ :host {
+   /deep/ .hoverZone {
+     display: block;
+     min-height: 2em;
+   }
+   /deep/ .Cbox {
+     display: flex;
+     > select,
+     > div {
+       float: none;
+     }
+     > div {
+      display: flex;
+      justify-content: flex-end;
+     }
+   }
+ }

--- a/ambari-logsearch-web/src/app/modules/shared/components/time-zone-map-input/time-zone-map-input.component.spec.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/components/time-zone-map-input/time-zone-map-input.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TimeZoneMapInputComponent } from './time-zone-map-input.component';
+
+describe('TimeZoneMapInputComponent', () => {
+  let component: TimeZoneMapInputComponent;
+  let fixture: ComponentFixture<TimeZoneMapInputComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TimeZoneMapInputComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TimeZoneMapInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ambari-logsearch-web/src/app/modules/shared/components/time-zone-map-input/time-zone-map-input.component.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/components/time-zone-map-input/time-zone-map-input.component.ts
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  Component,
+  Input,
+  Output,
+  AfterViewInit,
+  EventEmitter,
+  forwardRef,
+  OnChanges,
+  SimpleChanges
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import * as moment from 'moment-timezone';
+import * as $ from 'jquery';
+
+@Component({
+  selector: 'time-zone-map-input',
+  templateUrl: './time-zone-map-input.component.html',
+  styleUrls: ['./time-zone-map-input.component.less'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => TimeZoneMapInputComponent),
+      multi: true
+    }
+  ]
+})
+export class TimeZoneMapInputComponent implements AfterViewInit, ControlValueAccessor, OnChanges {
+
+  @Input()
+  value = moment.tz.guess();
+  
+  @Input()
+  mapElementId = 'timeZoneMap';
+  
+  @Input()
+  mapOptions = {
+    quickLink: [
+      {
+        PST: 'PST',
+        MST: 'MST',
+        CST: 'CST',
+        EST: 'EST',
+        GMT: 'GMT',
+        LONDON: 'Europe/London',
+        IST: 'IST'
+      }
+    ]
+  };
+
+  @Output()
+  onChange = new EventEmitter();
+
+  controlValueAccessorOnchange;
+  
+  constructor() { }
+
+  ngAfterViewInit() {
+    this.initMap();
+  }
+
+  ngOnChanges(change: SimpleChanges) {
+    if (change.value) {
+      this.setTimeZoneSelection(this.value);
+    }
+  }
+
+  getMapElement() {
+    return $(`#${this.mapElementId}`);
+  }
+
+  getSelectElement() {
+    return this.getMapElement().find('select');
+  }
+
+  initMap() {
+    const mapElement: any = this.getMapElement();
+    let timeZoneSelect;
+    let lastValue;
+    mapElement.WorldMapGenerator(this.mapOptions);
+    mapElement.on('click', (event) => {
+      const currentValue = timeZoneSelect && timeZoneSelect.val();
+      if (currentValue !== lastValue) {
+        this.onChange.emit(currentValue);
+        if (this.controlValueAccessorOnchange) {
+          this.controlValueAccessorOnchange(currentValue);
+        }
+      }
+    });
+    timeZoneSelect = this.getSelectElement();
+    timeZoneSelect.removeClass('btn btn-default')
+      .addClass('form-control')
+      .val(this.value || moment.tz.guess());
+  }
+
+  setTimeZoneSelection(timeZone) {
+    this.getSelectElement().val(timeZone);
+    this.getMapElement().find('[data-selected=true]').attr('data-selected', 'false');
+    this.getMapElement().find(`[data-timezone="${timeZone}"]`).attr('data-selected', 'true');
+  }
+
+  writeValue(value: any): void {
+    this.value = value;
+    this.setTimeZoneSelection(this.value);
+  }
+
+  registerOnChange(fn: any): void {
+    this.controlValueAccessorOnchange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+
+  }
+
+}

--- a/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.html
+++ b/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.html
@@ -1,0 +1,42 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<modal-dialog  class="user-settings-modal"
+  [visible]="visible$ | async"
+  [showCloseBtn]="true"
+  title="{{'userSettings.modalTitle' | translate}}"
+  (onCloseRequest)="handleCloseRequest($event)">
+  <section class="user-settings-form-section">
+    <form [formGroup]="form">
+      <div class="checkbox">
+        <div class="description">{{'userSettings.displayShortHostName.description' | translate}}</div>
+
+        <input type="radio" [value]="false" name="displayShortHostNames" id="userSettingsDisplayLongHostNames" formControlName="displayShortHostNames" />
+        <label class="radio" for="userSettingsDisplayLongHostNames">
+          {{'userSettings.displayShortHostName.valueFalse' | translate}}
+          <span class="host-name-example">({{hostNameExample$ | async}})</span>
+        </label>
+        
+        <input type="radio" [value]="true" name="displayShortHostNames" id="userSettingsDisplayShortHostNames" formControlName="displayShortHostNames" />
+        <label for="userSettingsDisplayShortHostNames" class="radio">
+          {{'userSettings.displayShortHostName.valueTrue' | translate}}
+          <span class="host-name-example">({{hostNameExampleShort$ | async}})</span>
+        </label>
+      </div>
+    </form>
+  </section>
+</modal-dialog>

--- a/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.html
+++ b/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.html
@@ -37,6 +37,8 @@
           <span class="host-name-example">({{hostNameExampleShort$ | async}})</span>
         </label>
       </div>
+      <div class="description">{{'userSettings.timeZone.description' | translate}}</div>
+      <time-zone-map-input [value]="timeZone$ | async" (onChange)="setTimeZoneValue($event)" formControlName="timeZone"></time-zone-map-input>
     </form>
   </section>
 </modal-dialog>

--- a/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.less
+++ b/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.less
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ @import '../../../shared/variables';
+
+ :host {
+   /deep/ modal-dialog.user-settings-modal .modal-dialog {
+     max-width: 40vw;
+     .host-name-example {
+       color: @fluid-gray-2;
+     }
+   }
+ }

--- a/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.less
+++ b/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.less
@@ -18,11 +18,18 @@
 
  @import '../../../shared/variables';
 
- :host {
-   /deep/ modal-dialog.user-settings-modal .modal-dialog {
-     max-width: 40vw;
-     .host-name-example {
-       color: @fluid-gray-2;
-     }
-   }
- }
+:host {
+  time-zone-map-input {
+    display: block;
+    margin-top: .5em;
+  }
+  /deep/ modal-dialog.user-settings-modal .modal-dialog {
+    max-width: 40vw;
+    .host-name-example {
+      color: @fluid-gray-2;
+    }
+  }
+  .description {
+    color: @fluid-gray-2;
+  }
+}

--- a/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.spec.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.spec.ts
@@ -34,6 +34,7 @@ import { HostsService, hosts } from '@app/services/storage/hosts.service';
 import * as userSettings from '@app/store/reducers/user-settings.reducers';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
 import { UserSettingsEffects } from '@app/store/effects/user-settings.effects';
+import { TimeZoneMapInputComponent } from '@app/modules/shared/components/time-zone-map-input/time-zone-map-input.component';
 
 import { UserSettingsComponent } from './user-settings.component';
 
@@ -66,7 +67,7 @@ describe('UserSettingsComponent', () => {
         NotificationService,
         UserSettingsService
       ],
-      declarations: [ UserSettingsComponent ],
+      declarations: [ UserSettingsComponent, TimeZoneMapInputComponent ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .compileComponents();

--- a/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.spec.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { Observable } from 'rxjs/Observable';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+
+import { TranslationModules, MockHttpRequestModules } from '@app/test-config.spec';
+import { AppStateService } from '@app/services/storage/app-state.service';
+import { NotificationService } from '@modules/shared/services/notification.service';
+import { NotificationsService } from 'angular2-notifications/src/notifications.service';
+import { UserSettingsService } from '@app/services/user-settings.service';
+import { HostsService, hosts } from '@app/services/storage/hosts.service';
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
+import { NotificationEffects } from '@app/store/effects/notification.effects';
+import { UserSettingsEffects } from '@app/store/effects/user-settings.effects';
+
+import { UserSettingsComponent } from './user-settings.component';
+
+describe('UserSettingsComponent', () => {
+  let component: UserSettingsComponent;
+  let fixture: ComponentFixture<UserSettingsComponent>;
+  let queryParams = {};
+  let queryParams$;
+
+
+  beforeEach(async(() => {
+    
+    TestBed.configureTestingModule({
+      imports: [ 
+        ...TranslationModules,
+        RouterTestingModule,
+        FormsModule,
+        ReactiveFormsModule,
+        StoreModule.provideStore({
+          hosts,
+          userSettings: userSettings.reducer
+        }),
+        EffectsModule.run(UserSettingsEffects),
+        EffectsModule.run(NotificationEffects)
+      ],
+      providers: [
+        ...MockHttpRequestModules,
+        AppStateService,
+        NotificationsService,
+        NotificationService,
+        UserSettingsService
+      ],
+      declarations: [ UserSettingsComponent ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+});

--- a/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.ts
@@ -82,9 +82,13 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
     this.destroyed$.complete();
   }
 
-  handleCloseRequest(clickEvent) {
+  handleCloseRequest = (clickEvent) => {
     clickEvent.preventDefault();
     clickEvent.stopPropagation();
+    this.close();
+  }
+
+  close() {
     this.route.queryParams.take(1).subscribe((queryParams) => {
       const params = { ...queryParams };
       delete params[this.visibilityQueryParamName];
@@ -95,11 +99,11 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
     });
   }
 
-  setFormValue(field, value) {
+  setFormValue(field, value, emitEvent = false) {
     if (this.form.controls[field]) {
       this.form.controls[field].setValue(value, {
-        onlySelf: true,
-        emitEvent: false
+        onlySelf: emitEvent,
+        emitEvent
       });
     }
   }
@@ -109,7 +113,7 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
   }
   
   setTimeZoneValue = (value) => {
-    this.setFormValue('timeZone', value);
+    this.setFormValue('timeZone', value, true);
   }
 
   onFormValueChanges = (form) => {

--- a/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/components/user-settings/user-settings.component.ts
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { FormGroup, FormControl } from '@angular/forms';
+
+import { Subject } from 'rxjs/Subject';
+import { Observable } from 'rxjs/Observable';
+import { Router, ActivatedRoute } from '@angular/router';
+
+import { Store } from '@ngrx/store';
+import { AppStore } from '@app/classes/models/store';
+import { selectDisplayShortHostNames, selectTimeZone } from '@app/store/selectors/user-settings.selectors';
+import { selectHostNames } from '@app/store/selectors/hosts.selectors';
+import { SetUserSettingsAction } from '@app/store/actions/user-settings.actions';
+
+@Component({
+  selector: 'user-settings',
+  templateUrl: './user-settings.component.html',
+  styleUrls: ['./user-settings.component.less']
+})
+export class UserSettingsComponent implements OnInit, OnDestroy {
+
+  @Input()
+  visibilityQueryParamName = 'showUserSettings';
+
+  demoHostName = 'subdomain01.company-domain.exp';
+  
+  visible$: Observable<boolean> = this.route.queryParams
+    .map(params => params)
+    .map((params): boolean => /^(show|yes|true|1)$/.test(params[this.visibilityQueryParamName]))
+    .distinctUntilChanged();
+
+  displayShortHostNames$: Observable<boolean> = this.store.select(selectDisplayShortHostNames);
+  timeZone$: Observable<string> = this.store.select(selectTimeZone);
+
+  hostNameExample$: Observable<string> = this.store.select(selectHostNames)
+    .map((hostNames: string[]) => hostNames && hostNames.length ? hostNames[0] : this.demoHostName)
+    .startWith(this.demoHostName);
+
+  hostNameExampleShort$: Observable<string> = this.hostNameExample$.map((hostName: string) => hostName.split('.')[0])
+
+  userSettingsFormGroup = new FormGroup({
+    displayShortHostName: new FormControl()
+  });
+
+  form: FormGroup = new FormGroup({
+    timeZone: new FormControl(),
+    displayShortHostNames: new FormControl()
+  });
+  
+  destroyed$: Subject<boolean> = new Subject();
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private store: Store<AppStore>
+  ) { }
+
+  ngOnInit() {
+    this.displayShortHostNames$.distinctUntilChanged().takeUntil(this.destroyed$).subscribe(this.setDisplayShortHostNamesValue);
+    this.timeZone$.distinctUntilChanged().takeUntil(this.destroyed$).subscribe(this.setTimeZoneValue);
+    this.form.valueChanges.takeUntil(this.destroyed$).subscribe(this.onFormValueChanges);
+  }
+
+  ngOnDestroy() {
+    this.destroyed$.next(true);
+    this.destroyed$.complete();
+  }
+
+  handleCloseRequest(clickEvent) {
+    clickEvent.preventDefault();
+    clickEvent.stopPropagation();
+    this.route.queryParams.take(1).subscribe((queryParams) => {
+      const params = { ...queryParams };
+      delete params[this.visibilityQueryParamName];
+      this.router.navigate(['.'], {
+        queryParams: params,
+        relativeTo: this.route.root.firstChild
+      });
+    });
+  }
+
+  setFormValue(field, value) {
+    if (this.form.controls[field]) {
+      this.form.controls[field].setValue(value, {
+        onlySelf: true,
+        emitEvent: false
+      });
+    }
+  }
+
+  setDisplayShortHostNamesValue = (value) => {
+    this.setFormValue('displayShortHostNames', value);
+  }
+  
+  setTimeZoneValue = (value) => {
+    this.setFormValue('timeZone', value);
+  }
+
+  onFormValueChanges = (form) => {
+    this.store.dispatch(new SetUserSettingsAction( this.form.getRawValue() ));
+  }
+
+}

--- a/ambari-logsearch-web/src/app/modules/shared/shared.module.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/shared.module.ts
@@ -19,7 +19,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BrowserModule, Title } from '@angular/platform-browser';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Http } from '@angular/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NotificationsService as Angular2NotificationsService } from 'angular2-notifications/src/notifications.service';
@@ -41,12 +41,14 @@ import { DataLoadingIndicatorComponent } from '@app/modules/shared/components/da
 import { ModalDialogComponent } from './components/modal-dialog/modal-dialog.component';
 import { LoadingIndicatorComponent } from './components/loading-indicator/loading-indicator.component';
 import { CircleProgressBarComponent } from './components/circle-progress-bar/circle-progress-bar.component';
+import { UserSettingsComponent } from './components/user-settings/user-settings.component';
 
 @NgModule({
   imports: [
     BrowserModule,
     CommonModule,
     FormsModule,
+    ReactiveFormsModule,
     BrowserAnimationsModule,
     NgObjectPipesModule,
     TranslateModule.forChild({
@@ -66,7 +68,8 @@ import { CircleProgressBarComponent } from './components/circle-progress-bar/cir
     DataLoadingIndicatorComponent,
     ModalDialogComponent,
     LoadingIndicatorComponent,
-    CircleProgressBarComponent
+    CircleProgressBarComponent,
+    UserSettingsComponent
   ],
   providers: [
     Title,
@@ -83,7 +86,8 @@ import { CircleProgressBarComponent } from './components/circle-progress-bar/cir
     DataLoadingIndicatorComponent,
     ModalDialogComponent,
     LoadingIndicatorComponent,
-    CircleProgressBarComponent
+    CircleProgressBarComponent,
+    UserSettingsComponent
   ]
 })
 export class SharedModule { }

--- a/ambari-logsearch-web/src/app/modules/shared/shared.module.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/shared.module.ts
@@ -43,6 +43,8 @@ import { LoadingIndicatorComponent } from './components/loading-indicator/loadin
 import { CircleProgressBarComponent } from './components/circle-progress-bar/circle-progress-bar.component';
 import { UserSettingsComponent } from './components/user-settings/user-settings.component';
 
+import { TimeZoneMapInputComponent } from './components/time-zone-map-input/time-zone-map-input.component';
+
 @NgModule({
   imports: [
     BrowserModule,
@@ -69,7 +71,8 @@ import { UserSettingsComponent } from './components/user-settings/user-settings.
     ModalDialogComponent,
     LoadingIndicatorComponent,
     CircleProgressBarComponent,
-    UserSettingsComponent
+    UserSettingsComponent,
+    TimeZoneMapInputComponent
   ],
   providers: [
     Title,
@@ -87,7 +90,8 @@ import { UserSettingsComponent } from './components/user-settings/user-settings.
     ModalDialogComponent,
     LoadingIndicatorComponent,
     CircleProgressBarComponent,
-    UserSettingsComponent
+    UserSettingsComponent,
+    TimeZoneMapInputComponent
   ]
 })
 export class SharedModule { }

--- a/ambari-logsearch-web/src/app/pipes/host-name.pipe.ts
+++ b/ambari-logsearch-web/src/app/pipes/host-name.pipe.ts
@@ -16,18 +16,25 @@
  * limitations under the License.
  */
 
-import { TestBed, inject } from '@angular/core/testing';
+import { Pipe, PipeTransform } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { AppStore } from '@app/classes/models/store';
+import { Observable } from 'rxjs/Observable';
 
-import { UserSettingsService } from './user-settings.service';
+import { selectDisplayShortHostNames } from '@app/store/selectors/user-settings.selectors';
 
-describe('UserSettingsService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [UserSettingsService]
-    });
-  });
+@Pipe({
+  name: 'hostName'
+})
+export class HostNamePipe implements PipeTransform {
 
-  it('should be created', inject([UserSettingsService], (service: UserSettingsService) => {
-    expect(service).toBeTruthy();
-  }));
-});
+  constructor(private store: Store<AppStore>) {
+  }
+
+  transform(hostName: string): Observable<string> {
+    return this.store.select(selectDisplayShortHostNames).map((displayShortHostNames: boolean): string => (
+      displayShortHostNames ? hostName.split('.')[0] : hostName
+    ));
+  }
+
+}

--- a/ambari-logsearch-web/src/app/services/component-generator.service.spec.ts
+++ b/ambari-logsearch-web/src/app/services/component-generator.service.spec.ts
@@ -52,6 +52,7 @@ import * as auth from '@app/store/reducers/auth.reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
 
 describe('ComponentGeneratorService', () => {
   beforeEach(() => {
@@ -72,7 +73,8 @@ describe('ComponentGeneratorService', () => {
           components,
           serviceLogsTruncated,
           tabs,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings: userSettings.reducer
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects),

--- a/ambari-logsearch-web/src/app/services/filter-history.guard.ts
+++ b/ambari-logsearch-web/src/app/services/filter-history.guard.ts
@@ -51,7 +51,8 @@ export class FilterHistoryIndexGuard implements CanActivate {
   }
 
   addFilterHistoryIndexToUrl(url, index) {
-    return `${url};${this.filterHistoryIndexUrlParamName}=${index}`;
+    const [mainUrl, queryParams] = url.split('?');
+    return `${mainUrl};${this.filterHistoryIndexUrlParamName}=${index}${queryParams ? '?' : ''}${queryParams || ''}`;
   }
 
   canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {

--- a/ambari-logsearch-web/src/app/services/history-manager.service.spec.ts
+++ b/ambari-logsearch-web/src/app/services/history-manager.service.spec.ts
@@ -52,6 +52,7 @@ import * as auth from '@app/store/reducers/auth.reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
 
 describe('HistoryManagerService', () => {
   beforeEach(() => {
@@ -74,7 +75,8 @@ describe('HistoryManagerService', () => {
           hosts,
           serviceLogsTruncated,
           tabs,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings: userSettings.reducer
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects)

--- a/ambari-logsearch-web/src/app/services/http-client.service.ts
+++ b/ambari-logsearch-web/src/app/services/http-client.service.ts
@@ -201,6 +201,7 @@ export class HttpClientService extends Http {
     const req = super.request(this.generateUrl(url), options).first().share()
       .map(response => response)
       .catch((error: any) => {
+        this.requestsPending.next(this.requestsPending.getValue() - 1);
         return handleResponseError(error) ? Observable.of(error) : Observable.throw(error);
       });
     req.subscribe(() => this.requestsPending.next(this.requestsPending.getValue() - 1));

--- a/ambari-logsearch-web/src/app/services/http-client.service.ts
+++ b/ambari-logsearch-web/src/app/services/http-client.service.ts
@@ -105,6 +105,11 @@ export class HttpClientService extends Http {
     },
     shipperClusterServiceConfigurationTest: {
       url: variables => `shipper/input/${variables.cluster}/test`
+    },
+
+    userSettings: {
+      url: 'metadata/list',
+      params: () => ({type: 'user_settings'})
     }
   };
 

--- a/ambari-logsearch-web/src/app/services/logs-breadcrumbs-resolver.service.ts
+++ b/ambari-logsearch-web/src/app/services/logs-breadcrumbs-resolver.service.ts
@@ -34,7 +34,7 @@ export class LogsBreadcrumbsResolverService implements Resolve<string[]> {
     const activeTabParam: string = this.routingUtilService.getParamFromActivatedRouteSnapshot(route, 'activeTab');
     const breadcrumbs: string[] = ['logs.title'];
     return this.tabStoreService.findInCollection((tab: LogTypeTab) => tab.id === activeTabParam).first().map((tab: LogTypeTab) => {
-      breadcrumbs.push(tab.label);
+      breadcrumbs.push(<string>tab.label);
       return breadcrumbs;
     });
   }

--- a/ambari-logsearch-web/src/app/services/logs-breadcrumbs-resolver.service.ts
+++ b/ambari-logsearch-web/src/app/services/logs-breadcrumbs-resolver.service.ts
@@ -34,7 +34,7 @@ export class LogsBreadcrumbsResolverService implements Resolve<string[]> {
     const activeTabParam: string = this.routingUtilService.getParamFromActivatedRouteSnapshot(route, 'activeTab');
     const breadcrumbs: string[] = ['logs.title'];
     return this.tabStoreService.findInCollection((tab: LogTypeTab) => tab.id === activeTabParam).first().map((tab: LogTypeTab) => {
-      breadcrumbs.push(<string>tab.label);
+      breadcrumbs.push(tab.label);
       return breadcrumbs;
     });
   }

--- a/ambari-logsearch-web/src/app/services/logs-container.service.spec.ts
+++ b/ambari-logsearch-web/src/app/services/logs-container.service.spec.ts
@@ -50,6 +50,8 @@ import * as auth from '@app/store/reducers/auth.reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
 import { NotificationEffects } from '@app/store/effects/notification.effects';
+import { UserSettingsEffects } from '@app/store/effects/user-settings.effects';
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
 
 describe('LogsContainerService', () => {
   beforeEach(() => {
@@ -70,7 +72,8 @@ describe('LogsContainerService', () => {
           hosts,
           serviceLogsTruncated,
           tabs,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings: userSettings.reducer
         }),
         EffectsModule.run(AuthEffects),
         EffectsModule.run(NotificationEffects),

--- a/ambari-logsearch-web/src/app/services/server-settings.service.spec.ts
+++ b/ambari-logsearch-web/src/app/services/server-settings.service.spec.ts
@@ -52,6 +52,9 @@ import { AuthService } from '@app/services/auth.service';
 import * as auth from '@app/store/reducers/auth.reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
+import { UserSettingsEffects } from '@app/store/effects/user-settings.effects';
+import { NotificationEffects } from '@app/store/effects/notification.effects';
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
 
 describe('ServerSettingsService', () => {
   beforeEach(() => {
@@ -73,7 +76,8 @@ describe('ServerSettingsService', () => {
           serviceLogsTruncated,
           tabs,
           dataAvailabilityStates,
-          auth: auth.reducer
+          auth: auth.reducer,
+          userSettings: userSettings.reducer
         }),
         EffectsModule.run(AuthEffects),
         ...TranslationModules

--- a/ambari-logsearch-web/src/app/services/server-settings.service.spec.ts
+++ b/ambari-logsearch-web/src/app/services/server-settings.service.spec.ts
@@ -16,10 +16,8 @@
  * limitations under the License.
  */
 
-import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {MockHttpRequestModules, TranslationModules} from '@app/test-config.spec';
+import {TestBed, inject} from '@angular/core/testing';
+import {MockHttpRequestModules, TranslationModules} from "@app/test-config.spec";
 import {StoreModule} from '@ngrx/store';
 import {AuditLogsService, auditLogs} from '@app/services/storage/audit-logs.service';
 import {ServiceLogsService, serviceLogs} from '@app/services/storage/service-logs.service';
@@ -36,43 +34,30 @@ import {ComponentsService, components} from '@app/services/storage/components.se
 import {HostsService, hosts} from '@app/services/storage/hosts.service';
 import {ServiceLogsTruncatedService, serviceLogsTruncated} from '@app/services/storage/service-logs-truncated.service';
 import {TabsService, tabs} from '@app/services/storage/tabs.service';
-import {HistoryManagerService} from '@app/services/history-manager.service';
 import {LogsContainerService} from '@app/services/logs-container.service';
-import {ServerSettingsService} from '@app/services/server-settings.service';
 import {UtilsService} from '@app/services/utils.service';
-import {ModalDialogComponent} from '@app/modules/shared/components/modal-dialog/modal-dialog.component';
-import {TimerSecondsPipe} from '@app/pipes/timer-seconds.pipe';
-import {ComponentLabelPipe} from '@app/pipes/component-label';
 
-import {ActionMenuComponent} from './action-menu.component';
-import { LogIndexFilterComponent } from '@app/components/log-index-filter/log-index-filter.component';
+import {ServerSettingsService} from './server-settings.service';
 import {ClusterSelectionService} from '@app/services/storage/cluster-selection.service';
 import {RouterTestingModule} from '@angular/router/testing';
-import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {RoutingUtilsService} from '@app/services/routing-utils.service';
 import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
+import {LogsStateService} from '@app/services/storage/logs-state.service';
 import {NotificationsService} from 'angular2-notifications/src/notifications.service';
 import {NotificationService} from '@modules/shared/services/notification.service';
 
-import { DataAvailabilityStatesStore, dataAvailabilityStates } from '@app/modules/app-load/stores/data-availability-state.store';
+import { dataAvailabilityStates, DataAvailabilityStatesStore } from '@app/modules/app-load/stores/data-availability-state.store';
 
-import * as auth from '@app/store/reducers/auth.reducers';
 import { AuthService } from '@app/services/auth.service';
+import * as auth from '@app/store/reducers/auth.reducers';
 import { EffectsModule } from '@ngrx/effects';
 import { AuthEffects } from '@app/store/effects/auth.effects';
-import { NotificationEffects } from '@app/store/effects/notification.effects';
 
-describe('ActionMenuComponent', () => {
-  let component: ActionMenuComponent;
-  let fixture: ComponentFixture<ActionMenuComponent>;
-
-  beforeEach(async(() => {
+describe('ServerSettingsService', () => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
-        FormsModule,
-        ReactiveFormsModule,
-        ...TranslationModules,
         StoreModule.provideStore({
           auditLogs,
           serviceLogs,
@@ -91,20 +76,12 @@ describe('ActionMenuComponent', () => {
           auth: auth.reducer
         }),
         EffectsModule.run(AuthEffects),
-        EffectsModule.run(NotificationEffects)
-      ],
-      declarations: [
-        LogIndexFilterComponent,
-        ActionMenuComponent,
-        ModalDialogComponent,
-        TimerSecondsPipe,
-        ComponentLabelPipe
+        ...TranslationModules
       ],
       providers: [
         ...MockHttpRequestModules,
-        HistoryManagerService,
-        LogsContainerService,
         ServerSettingsService,
+        LogsContainerService,
         UtilsService,
         AuditLogsService,
         ServiceLogsService,
@@ -127,19 +104,11 @@ describe('ActionMenuComponent', () => {
         NotificationService,
         DataAvailabilityStatesStore,
         AuthService
-      ],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    })
-    .compileComponents();
+      ]
+    });
+  });
+
+  it('should be created', inject([ServerSettingsService], (service: ServerSettingsService) => {
+    expect(service).toBeTruthy();
   }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ActionMenuComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it('should create component', () => {
-    expect(component).toBeTruthy();
-  });
 });

--- a/ambari-logsearch-web/src/app/services/server-settings.service.ts
+++ b/ambari-logsearch-web/src/app/services/server-settings.service.ts
@@ -1,0 +1,197 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from '@angular/core';
+import { FormGroup, FormControl } from '@angular/forms';
+import { Response } from '@angular/http';
+import { HomogeneousObject, LogLevelObject } from '@app/classes/object';
+import { LevelOverridesConfig, LogIndexFilterComponentConfig } from '@app/classes/settings';
+import { LogLevel } from '@app/classes/string';
+import { Filter } from '@app/classes/models/filter';
+import { LogsContainerService } from '@app/services/logs-container.service';
+import { HttpClientService } from '@app/services/http-client.service';
+import { UtilsService } from '@app/services/utils.service';
+import { AppSettingsService } from '@app/services/storage/app-settings.service';
+import { TranslateService } from '@ngx-translate/core';
+import { NotificationService } from '@modules/shared/services/notification.service';
+import { DataAvailabilityStatesStore } from '@app/modules/app-load/stores/data-availability-state.store';
+import { DataAvailabilityValues } from '@app/classes/string';
+
+@Injectable()
+export class ServerSettingsService {
+
+  settingsFormGroup: FormGroup = new FormGroup({
+    logIndexFilter: new FormControl()
+  });
+
+  currentValues = {
+    logIndexFilter: {}
+  };
+
+  readonly levelNames = this.logsContainer.logLevels.map((level: LogLevelObject): LogLevel => level.name);
+
+  constructor(
+    private logsContainer: LogsContainerService,
+    private httpClient: HttpClientService,
+    private utils: UtilsService,
+    private settingsStorage: AppSettingsService,
+    private translateService: TranslateService,
+    private notificationService: NotificationService,
+    private dataAvailablilityStore: DataAvailabilityStatesStore
+  ) {
+    this.dataAvailablilityStore.setParameter('logIndexFilter', DataAvailabilityValues.NOT_AVAILABLE);
+    settingsStorage.getParameter('logIndexFilters').subscribe((filters: HomogeneousObject<HomogeneousObject<Filter>>): void => {
+      const configs = this.parseLogIndexFilterObjects(filters);
+      this.settingsFormGroup.controls.logIndexFilter.setValue(configs);
+    });
+  }
+
+  loadIndexFilterConfig(clusterNames: string[]): void {
+    let processedRequests = 0;
+    const allFilters: HomogeneousObject<Filter> = {};
+    const totalCount = clusterNames.length;
+    this.dataAvailablilityStore.setParameter('logIndexFilter', DataAvailabilityValues.LOADING);
+    clusterNames.forEach((clusterName: string): void => {
+      this.httpClient.get('logIndexFilters', null, {
+        clusterName
+      }).subscribe((response: Response): void => {
+        const filters = response.json() && response.json().filter;
+        if (filters) {
+          Object.assign(allFilters, {
+            [clusterName]: filters
+          });
+          if (++processedRequests === totalCount) {
+            this.settingsStorage.setParameter('logIndexFilters', allFilters);
+            this.dataAvailablilityStore.setParameter('logIndexFilter', DataAvailabilityValues.AVAILABLE);
+            this.currentValues.logIndexFilter = allFilters;
+          }
+        }
+      });
+    });
+  }
+
+  handleLogIndexFilterUpdate = (response: Response, cluster?: string): void => {
+    const title: string = this.translateService.instant('logIndexFilter.update.title');
+    const resultStr: string = response instanceof Response && response.ok ? 'success' : 'failed';
+    const data: {[key: string]: any} = response instanceof Response && response.text() ? response.json() : {};
+    const message: string = this.translateService.instant(`logIndexFilter.update.${resultStr}`, {
+      message: '',
+      cluster: cluster || '',
+      ...data
+    });
+    this.notificationService.addNotification({
+      type: resultStr,
+      title,
+      message
+    });
+  }
+
+  saveIndexFilterConfig(): void {
+    const savedValue = this.currentValues.logIndexFilter;
+    const newValue = this.settingsFormGroup.controls.logIndexFilter.value;
+    const clusters = Object.keys(newValue);
+    const storedValue = {};
+    const addResponseHandler = (cluster: string) => {
+      return (response: Response) => {
+        this.handleLogIndexFilterUpdate(response, cluster);
+      };
+    };
+    clusters.forEach((clusterName: string): void => {
+      const savedConfig = savedValue[clusterName],
+        newConfig = this.getLogIndexFilterObject(newValue[clusterName]);
+      Object.assign(storedValue, {
+        [clusterName]: newConfig
+      });
+      if (!this.utils.isEqual(savedConfig, newConfig)) {
+        this.httpClient.put('logIndexFilters', {
+          filter: newConfig
+        }, null, {
+          clusterName
+        }).subscribe(addResponseHandler(clusterName), addResponseHandler(clusterName));
+      }
+    });
+    this.settingsStorage.setParameter('logIndexFilters', storedValue);
+  }
+
+  /**
+   * Convert log index filter data for usage in component
+   * @param {HomogeneousObject<HomogeneousObject<Filter>>} filters
+   * @returns {HomogeneousObject<LogIndexFilterComponentConfig[]>}
+   */
+  parseLogIndexFilterObjects(
+    filters: HomogeneousObject<HomogeneousObject<Filter>>
+  ): HomogeneousObject<LogIndexFilterComponentConfig[]> {
+    const levels = this.levelNames;
+    return filters ? Object.keys(filters).reduce((
+      clustersCurrent: HomogeneousObject<LogIndexFilterComponentConfig[]>, clusterName: string
+    ): HomogeneousObject<LogIndexFilterComponentConfig[]> => {
+      const clusterConfigs = filters[clusterName],
+        clusterParsedObject = Object.keys(clusterConfigs).map((componentName: string) => {
+          const componentConfigs = clusterConfigs[componentName],
+            levelProperties = levels.reduce((
+              levelsCurrent: HomogeneousObject<LevelOverridesConfig>, levelName: LogLevel
+            ): LevelOverridesConfig => {
+              return Object.assign({}, levelsCurrent, {
+                [levelName]: {
+                  defaults: componentConfigs.defaultLevels.indexOf(levelName) > -1,
+                  overrides: componentConfigs.overrideLevels.indexOf(levelName) > -1
+                }
+              });
+            }, {});
+          return Object.assign({
+            name: componentName,
+            label: componentConfigs.label,
+            hasOverrides: false,
+            hosts: componentConfigs.hosts.join(),
+            expiryTime: componentConfigs.expiryTime
+          }, levelProperties);
+        });
+      return Object.assign({}, clustersCurrent, {
+        [clusterName]: clusterParsedObject
+      });
+    }, {}) : {};
+  }
+
+  /**
+   * Convert data from log index filter component to format for PUT API call
+   * @param configs
+   * @returns {HomogeneousObject<Filter>}
+   */
+  private getLogIndexFilterObject(configs): HomogeneousObject<Filter> {
+    const levelNames = this.levelNames;
+    return configs.reduce((
+      currentObject: HomogeneousObject<Filter>, componentConfig: LogIndexFilterComponentConfig
+    ): HomogeneousObject<Filter> => {
+      const hosts = componentConfig.hosts;
+      return Object.assign({}, currentObject, {
+        [componentConfig.name]: {
+          defaultLevels: levelNames.filter((levelName: LogLevel): boolean => componentConfig[levelName].defaults),
+          expiryTime: componentConfig.expiryTime,
+          hosts: hosts ? hosts.split(',') : [],
+          label: componentConfig.label,
+          overrideLevels: levelNames.filter((levelName: LogLevel): boolean => componentConfig[levelName].overrides)
+        }
+      });
+    }, {});
+  }
+
+  setTimeZone(timeZone: string): void {
+    this.settingsStorage.setParameter('timeZone', timeZone);
+  }
+
+}

--- a/ambari-logsearch-web/src/app/services/storage/reducers.service.ts
+++ b/ambari-logsearch-web/src/app/services/storage/reducers.service.ts
@@ -39,6 +39,7 @@ import {dataAvailabilityStates} from '@app/modules/app-load/stores/data-availabi
 import * as auth from '@app/store/reducers/auth.reducers';
 import * as filterHistory from '@app/store/reducers/filter-history.reducers';
 import * as auditLogRepos from '@app/store/reducers/audit-log-repos.reducers';
+import * as userSettings from '@app/store/reducers/user-settings.reducers';
 
 export const reducers = {
   appSettings,
@@ -61,7 +62,8 @@ export const reducers = {
   dataAvailabilityStates,
   auth: auth.reducer,
   filterHistory: filterHistory.reducer,
-  auditLogRepos: auditLogRepos.reducer
+  auditLogRepos: auditLogRepos.reducer,
+  userSettings: userSettings.reducer
 };
 
 export function reducer(state: any, action: any) {

--- a/ambari-logsearch-web/src/app/store/actions/user-settings.actions.ts
+++ b/ambari-logsearch-web/src/app/store/actions/user-settings.actions.ts
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Action } from '@ngrx/store';
+
+import { UserSettingsState } from '@app/store/reducers/user-settings.reducers';
+
+export enum UserSettingsActionTypes {
+  LOAD = '[User Settings] Load from server',
+  LOAD_SUCCESS = '[User Settings] Load from server is successful',
+  LOAD_FAILED = '[User Settings] Load from server is failed',
+
+  SAVE = '[User Settings] Save to server',
+  SAVE_SUCCESS = '[User Settings] Save to server is successful',
+  SAVE_FAILED = '[User Settings] Save to server is failed',
+
+  SET = '[User Settings] Set to state'
+}
+
+export class LoadUserSettingsAction implements Action {
+  readonly type = UserSettingsActionTypes.LOAD;
+  constructor() {}
+}
+
+export class LoadUserSettingsSuccessAction implements Action {
+  readonly type = UserSettingsActionTypes.LOAD_SUCCESS;
+  constructor(public payload: UserSettingsState) {}
+}
+
+export class LoadUserSettingsFailedAction implements Action {
+  readonly type = UserSettingsActionTypes.LOAD_FAILED;
+  constructor(public payload: {[key: string]: any}) {}
+}
+
+export class SaveUserSettingsAction implements Action {
+  readonly type = UserSettingsActionTypes.SAVE;
+  constructor(public payload: UserSettingsState) {}
+}
+
+export class SaveUserSettingsSuccessAction implements Action {
+  readonly type = UserSettingsActionTypes.SAVE_SUCCESS;
+  constructor(public payload: UserSettingsState) {}
+}
+
+export class SaveUserSettingsFailedAction implements Action {
+  readonly type = UserSettingsActionTypes.SAVE_FAILED;
+  constructor(public payload: {[key: string]: any}) {}
+}
+
+export class SetUserSettingsAction implements Action {
+  readonly type = UserSettingsActionTypes.SET;
+  constructor(public payload: {[key: string]: any}) {}
+}
+
+export type UserSettingsActions = SetUserSettingsAction
+  | LoadUserSettingsAction
+  | LoadUserSettingsSuccessAction
+  | LoadUserSettingsFailedAction
+  | SaveUserSettingsAction
+  | SaveUserSettingsSuccessAction
+  | SaveUserSettingsFailedAction;

--- a/ambari-logsearch-web/src/app/store/effects/user-settings.effects.ts
+++ b/ambari-logsearch-web/src/app/store/effects/user-settings.effects.ts
@@ -42,6 +42,9 @@ import { AuthActionTypes } from '@app/store/actions/auth.actions';
 import { UserSettingsState } from '@app/store/reducers/user-settings.reducers';
 import { UserSettingsService } from '@app/services/user-settings.service';
 
+import { AddNotificationAction, NotificationActions } from '@app/store/actions/notification.actions';
+import { NotificationType } from '@modules/shared/services/notification.service';
+
 @Injectable()
 export class UserSettingsEffects {
   constructor(
@@ -50,7 +53,7 @@ export class UserSettingsEffects {
     private httpClient: HttpClientService,
     private userSettingsService: UserSettingsService
   ) {
-    this.store.select(selectUserSettingsState).skip(1).subscribe((settings) => {
+    this.store.select(selectUserSettingsState).skip(2).subscribe((settings) => {
       this.onUserSettingsStateChanged(settings);
     });
   }
@@ -101,5 +104,21 @@ export class UserSettingsEffects {
         return response.ok ? new SaveUserSettingsSuccessAction(result) : new SaveUserSettingsFailedAction(result);
       });
     });
+
+    @Effect()
+    saveSuccessAction: Observable<NotificationActions> = this.actions$
+      .ofType(UserSettingsActionTypes.SAVE_SUCCESS)
+      .map(() => new AddNotificationAction({
+        type: NotificationType.SUCCESS,
+        message: 'userSettings.saveAction.success'
+      }));
+    
+    @Effect()
+    saveFailedAction: Observable<NotificationActions> = this.actions$
+      .ofType(UserSettingsActionTypes.SAVE_FAILED)
+      .map(() => new AddNotificationAction({
+        type: NotificationType.ERROR,
+        message: 'userSettings.saveAction.error'
+      }));
 
 }

--- a/ambari-logsearch-web/src/app/store/effects/user-settings.effects.ts
+++ b/ambari-logsearch-web/src/app/store/effects/user-settings.effects.ts
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from '@angular/core';
+import { Actions, Effect } from '@ngrx/effects';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/skip';
+import 'rxjs/add/operator/mapTo';
+import { Store } from '@ngrx/store';
+
+import { AppStore } from '@app/classes/models/store';
+import { HttpClientService } from '@app/services/http-client.service';
+
+import { selectUserSettingsState } from '@app/store/selectors/user-settings.selectors';
+import { 
+  UserSettingsActions,
+  LoadUserSettingsAction,
+  LoadUserSettingsSuccessAction,
+  LoadUserSettingsFailedAction,
+  SetUserSettingsAction,
+  SaveUserSettingsAction,
+  SaveUserSettingsSuccessAction,
+  SaveUserSettingsFailedAction,
+  UserSettingsActionTypes 
+} from '@app/store/actions/user-settings.actions';
+import { AuthActionTypes } from '@app/store/actions/auth.actions';
+import { UserSettingsState } from '@app/store/reducers/user-settings.reducers';
+import { UserSettingsService } from '@app/services/user-settings.service';
+
+@Injectable()
+export class UserSettingsEffects {
+  constructor(
+    private actions$: Actions,
+    private store: Store<AppStore>,
+    private httpClient: HttpClientService,
+    private userSettingsService: UserSettingsService
+  ) {
+    this.store.select(selectUserSettingsState).skip(1).subscribe((settings) => {
+      this.onUserSettingsStateChanged(settings);
+    });
+  }
+
+  onUserSettingsStateChanged = (userSettingsState) => {
+    this.store.dispatch(new SaveUserSettingsAction(userSettingsState));
+  }
+
+  @Effect()
+  authorizedAction: Observable<UserSettingsActions> = this.actions$
+    .ofType(AuthActionTypes.AUTHORIZED)
+    .mapTo( new LoadUserSettingsAction() );
+  
+  @Effect()
+  loadAction: Observable<UserSettingsActions> = this.actions$
+    .ofType(UserSettingsActionTypes.LOAD)
+    .switchMap((action) => {
+      return this.httpClient.get('userSettings').map((response) => {
+        const responseBody = response.json();
+        const state = this.userSettingsService.parseMetaDataToUserSettingsState(responseBody);
+        return response.ok ? new LoadUserSettingsSuccessAction(state) : new LoadUserSettingsFailedAction(responseBody);
+      });
+    });
+  
+  @Effect()
+  loadSuccessAction: Observable<UserSettingsActions> = this.actions$
+    .ofType(UserSettingsActionTypes.LOAD_SUCCESS)
+    .map((userSettings: LoadUserSettingsSuccessAction) => new SetUserSettingsAction(userSettings.payload));
+    
+  @Effect()
+  saveAction: Observable<UserSettingsActions> = this.actions$
+    .ofType(UserSettingsActionTypes.SAVE)
+    .map((action) => {
+      const settings: UserSettingsState = action.payload;
+      const metaData = Object.keys(settings).reduce((currentMetaData, key: string) => ([
+        ...currentMetaData,
+        {
+          name: key,
+          value: settings[key].toString(),
+          type: 'user_settings'
+        }
+      ]), []);
+      return metaData;
+    })
+    .switchMap((userSettingsMetaData) => {
+      return this.httpClient.post('userSettings', userSettingsMetaData).map((response) => {
+        const result: UserSettingsState = <UserSettingsState>(response.json());
+        return response.ok ? new SaveUserSettingsSuccessAction(result) : new SaveUserSettingsFailedAction(result);
+      });
+    });
+
+}

--- a/ambari-logsearch-web/src/app/store/reducers/user-settings.reducers.ts
+++ b/ambari-logsearch-web/src/app/store/reducers/user-settings.reducers.ts
@@ -16,36 +16,35 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
+import { UserSettingsActions, UserSettingsActionTypes } from '@app/store/actions/user-settings.actions';
+import * as moment from 'moment-timezone';
 
-import { UserSettingsState, initialState, ServerMetaDatum } from '@app/store/reducers/user-settings.reducers';
+export interface ServerMetaDatum {
+  type: string;
+  name: string;
+  value: string;
+};
+ export interface UserSettingsState {
+  timeZone: string;
+  displayShortHostNames: boolean;
+ };
 
-@Injectable()
-export class UserSettingsService {
+ export const initialState: UserSettingsState = {
+  timeZone: moment.tz.guess(),
+  displayShortHostNames: false
+ };
 
-  constructor() { }
-
-  parseMetaDatumValueToStateValue(metaDatum: ServerMetaDatum): any {
-    const {name, value} = metaDatum;
-    switch (name) {
-      case 'displayShortHostNames': {
-        return value === 'true';
-      }
-      default: {
-        return value
-      }
+ export function reducer(state = initialState, action: UserSettingsActions): UserSettingsState {
+  switch (action.type) {
+    case UserSettingsActionTypes.SET : {
+      return {
+        ...state,
+        ...action.payload
+      };
+    }
+    default: {
+      return state;
     }
   }
-
-  parseMetaDataToUserSettingsState(metaData: ServerMetaDatum[]): UserSettingsState {
-    const parsedState = metaData.reduce((currentState, metaDatum: ServerMetaDatum) => ({
-      ...currentState,
-      [metaDatum.name]: this.parseMetaDatumValueToStateValue(metaDatum)
-    }), {});
-    return {
-      ...initialState,
-      ...parsedState
-    }
-  }
-
-}
+ }
+ 

--- a/ambari-logsearch-web/src/app/store/reducers/user-settings.reducers.ts
+++ b/ambari-logsearch-web/src/app/store/reducers/user-settings.reducers.ts
@@ -31,7 +31,7 @@ export interface ServerMetaDatum {
 
  export const initialState: UserSettingsState = {
   timeZone: moment.tz.guess(),
-  displayShortHostNames: false
+  displayShortHostNames: true
  };
 
  export function reducer(state = initialState, action: UserSettingsActions): UserSettingsState {

--- a/ambari-logsearch-web/src/app/store/selectors/hosts.selectors.ts
+++ b/ambari-logsearch-web/src/app/store/selectors/hosts.selectors.ts
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSelector, Selector } from 'reselect';
+
+import { AppStore } from '@app/classes/models/store';
+
+import { NodeItem } from '@app/classes/models/node-item';
+
+export const selectHostsList = (state: AppStore): NodeItem[] => state.hosts;
+
+export const selectHostNames = createSelector(
+  selectHostsList,
+  (hostNodeItems: NodeItem[]): string[] => hostNodeItems.map((hostNodeItem: NodeItem): string => hostNodeItem.name)
+);

--- a/ambari-logsearch-web/src/app/store/selectors/user-settings.selectors.ts
+++ b/ambari-logsearch-web/src/app/store/selectors/user-settings.selectors.ts
@@ -16,18 +16,21 @@
  * limitations under the License.
  */
 
-import { TestBed, inject } from '@angular/core/testing';
+import { createSelector, Selector } from 'reselect';
+import { AppStore } from '@app/classes/models/store';
 
-import { UserSettingsService } from './user-settings.service';
+import { UserSettingsState } from '@app/store/reducers/user-settings.reducers';
 
-describe('UserSettingsService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [UserSettingsService]
-    });
-  });
+export const selectUserSettingsState = (state: AppStore): UserSettingsState => state.userSettings;
 
-  it('should be created', inject([UserSettingsService], (service: UserSettingsService) => {
-    expect(service).toBeTruthy();
-  }));
-});
+export const selectDisplayShortHostNames = createSelector(
+  selectUserSettingsState,
+  (userSettings: UserSettingsState): boolean => userSettings.displayShortHostNames
+);
+
+export const selectTimeZone = createSelector(
+  selectUserSettingsState,
+  (userSettings: UserSettingsState): string => {
+    return userSettings.timeZone
+  }
+);

--- a/ambari-logsearch-web/src/assets/i18n/en.json
+++ b/ambari-logsearch-web/src/assets/i18n/en.json
@@ -386,6 +386,9 @@
       "valueFalse": "Full hostname",
       "valueTrue": "Short hostname"
     },
+    "timeZone": {
+      "description": "Choose the time zone will be used throughout Log Search"
+    },
     "saveAction": {
       "success": "The user settings has been saved.",
       "error": "Some error happened saving the user settings."

--- a/ambari-logsearch-web/src/assets/i18n/en.json
+++ b/ambari-logsearch-web/src/assets/i18n/en.json
@@ -377,6 +377,19 @@
     "page": "Page",
     "query": "Query",
     "users": "Users"
+  },
+
+  "userSettings": {
+    "modalTitle": "User Settings",
+    "displayShortHostName": {
+      "description": "Choose the way Hostname will be displayed throughout Log Search",
+      "valueFalse": "Full hostname",
+      "valueTrue": "Short hostname"
+    },
+    "saveAction": {
+      "success": "The user settings has been saved.",
+      "error": "Some error happened saving the user settings."
+    }
   }
 
 }


### PR DESCRIPTION
# What changes were proposed in this pull request?

Two main changes are here:
- adding the user settings feature
- displaying the short or full host names depending of the related user setting

### User settings
We had user settings service before but it was settings of the log index filter which is connected to the application not the user. So that the first change was to clean this up: renaming the user-settings to server-settings and creating user settings (with reducers, actions, effects and with a helper service).
There are multiple files affected by this rename change.

I added two user settings there:
- host name display setting
- time zone setting

Since the time zone settings moved to the user settings I moved the settings window on application level as I did with the user settings. In order to add the time zone map to the user settings window I created a separate component for the time zone selecting to decrease the dependency.

The two settings modal is available in deep link via query params.

### Display short or long host names depending on the user settings
I created a(n observable) pipe for displaying the host name in templates easier. We have a trade off: the open log tab label is not changeable after it is rendered.

## How was this patch tested?

It was tested manually and by unit tests:
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 295 of 295 SUCCESS (12.245 secs / 12.091 secs)
✨  Done in 43.81s.
```
I also had a pair code review with @sardell (Shane Ardell), thanks for this.
Please review [Ambari Contributing Guide]

(https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
