### PR TITLE
[AMBARI-25016] [Log Search UI] There is console error about TimeZonePicker initialisation

### DIFF
--- a/ambari-logsearch-web/src/app/components/timezone-picker/timezone-picker.component.html
+++ b/ambari-logsearch-web/src/app/components/timezone-picker/timezone-picker.component.html
@@ -18,7 +18,6 @@
 <modal-dialog [visible]="visible$ | async"
   [showCloseBtn]="true"
   (onCloseRequest)="onCloseRequest($event)"
-  (onAfterViewInit)="initMap()"
   class="time-zone-modal">
   <time-zone-map-input [value]="timeZone$ | async" (onChange)="onTimeZoneSelect($event)" [mapElementId]="mapElementId"></time-zone-map-input>
   <footer>


### PR DESCRIPTION
# What changes were proposed in this pull request?

Removing the old `afterViewInit` handler, because the map is initialised within the new component.

## How was this patch tested?

It was tested manually by opening console and checking time zone modal functionality, also by unit tests:
```
Chrome 70.0.3538 (Mac OS X 10.13.6): Executed 295 of 295 SUCCESS (8.474 secs / 8.197 secs)
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
