### PR TITLE
[AMBARI-25015] [Log Search UI] Cluster search param added by default when the app loaded on service logs screen

### DIFF
--- a/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.ts
+++ b/ambari-logsearch-web/src/app/components/filters-panel/filters-panel.component.ts
@@ -119,23 +119,29 @@ export class FiltersPanelComponent implements OnDestroy, OnInit {
     const logsType = this.logsContainerService.logsTypeMap[currentLogsType];
     const fieldsModel: any = logsType && logsType.fieldsModel;
     let subType: string;
-    let fields: Observable<any>;
+    let fields$: Observable<any>;
     switch (currentLogsType) {
       case 'auditLogs':
-        fields = fieldsModel.getParameter(subType ? 'overrides' : 'defaults');
+        fields$ = fieldsModel.getParameter(subType ? 'overrides' : 'defaults');
         if (subType) {
-          fields = fields.map(items => items && items[subType]);
+          fields$ = fields$.map(items => items && items[subType]);
         }
         break;
       case 'serviceLogs':
-        fields = fieldsModel.getAll();
+        fields$ = fieldsModel.getAll();
         break;
       default:
-        fields = Observable.from([]);
+        fields$ = Observable.from([]);
         break;
     }
-    this.searchBoxItems$ = fields.defaultIfEmpty([]).map(items => items ? items.filter(field => field.filterable) : [])
-      .map(this.utils.logFieldToListItemMapper);
+    this.searchBoxItems$ = fields$.defaultIfEmpty([]).map(items => items ? items.filter(field => field.filterable) : [])
+      .map(this.utils.logFieldToListItemMapper)
+      .map((fields: ListItem[]): ListItem[] => fields.map(
+        (field: ListItem): ListItem => ({
+          ...field,
+          isChecked: false
+        })
+      ));
   }
 
   isFilterConditionDisplayed(key: string): boolean {

--- a/ambari-logsearch-web/src/app/components/search-box/search-box.component.html
+++ b/ambari-logsearch-web/src/app/components/search-box/search-box.component.html
@@ -21,7 +21,11 @@
 <ng-container *ngFor="let parameter of parameters">
 <label class="parameter-label" [class.exclude]="parameter.isExclude" [class.include]="!parameter.isExclude">
   {{parameter.label | translate}}:
-  <span class="parameter-value">{{(parameter.name === 'type' ? (parameter.value | componentLabel | async) : parameter.value)}}</span>
+  <ng-container [ngSwitch]="parameter.name">
+      <span *ngSwitchCase="type" class="parameter-value">{{parameter.value | componentLabel | async}}</span>
+      <span *ngSwitchCase="host" class="parameter-value">{{parameter.value | hostName | async}}</span>
+      <span *ngSwitchDefault class="parameter-value">{{parameter.value}}</span>
+  </ng-container>
   <span class="fa toggle-parameter action-icon" [ngClass]="{'fa-search-minus': parameter.isExclude, 'fa-search-plus': !parameter.isExclude}"
         (click)="toggleParameter($event, parameter.id)" tooltip="{{('filter.toggleTo.' + (parameter.isExclude ? 'include' : 'exclude')) | translate}}"></span>
   <span class="fa fa-times remove-parameter action-icon" (click)="removeParameter($event, parameter.id)"></span>

--- a/ambari-logsearch-web/src/app/components/search-box/search-box.component.spec.ts
+++ b/ambari-logsearch-web/src/app/components/search-box/search-box.component.spec.ts
@@ -26,6 +26,7 @@ import {UtilsService} from '@app/services/utils.service';
 import {SearchBoxComponent} from './search-box.component';
 import {ComponentsService, components} from '@app/services/storage/components.service';
 import {ComponentLabelPipe} from '@app/pipes/component-label';
+import {HostNamePipe} from "@app/pipes/host-name.pipe";
 
 describe('SearchBoxComponent', () => {
   let component: SearchBoxComponent;
@@ -35,6 +36,7 @@ describe('SearchBoxComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         ComponentLabelPipe,
+        HostNamePipe,
         SearchBoxComponent
       ],
       imports: [


### PR DESCRIPTION
# What changes were proposed in this pull request?

Set `isChecked` prop to `false` when we create the list for the available filter fields in order to prevent the auto selection. 

## How was this patch tested?

It was tested manually, loading the screens (audit and service logs screens) and via unit tests:
```
Chrome 70.0.3538 (Mac OS X 10.13.6): Executed 295 of 295 SUCCESS (8.843 secs / 8.668 secs)
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
