### PR TITLE
AMBARI-25054 - LogSearch - In configuration Editor page, under validator section, component Name suggestions are always over hiding with "livy2_server" component name.

### DIFF
--- a/ambari-logsearch-web/src/app/modules/shipper/components/shipper-service-configuration-form/shipper-service-configuration-form.component.html
+++ b/ambari-logsearch-web/src/app/modules/shipper/components/shipper-service-configuration-form/shipper-service-configuration-form.component.html
@@ -86,7 +86,8 @@
                      [typeahead]="configurationComponents$ | async"
                      [typeaheadItemTemplate]="typeAheadTpl"
                      [typeaheadMinLength]="0"
-                     [disableControl]="configurationForm.invalid">
+                     [disableControl]="configurationForm.invalid"
+                     autocomplete="off">
             </div>
             <div class="form-group" [class.has-warning]="sampleDataField.invalid">
               <label>


### PR DESCRIPTION
# What changes were proposed in this pull request?

On configuration Editor page, under validator section, component Name suggestions are always over hiding with another dropdown list which is shown by the browsers autocomplete function.
Fix: turn off autocomplete for component name  input field

![screen shot 2018-12-19 at 11 47 03 am](https://user-images.githubusercontent.com/33458261/50215618-db847180-0383-11e9-94ab-caed07ee00c0.png)

## How was this patch tested?

1. Login into LogSearch portal.
2. Click on drop down present at top right side.
3. Select Configuration editor.
4. Select any service present at left side.
5. Click on component Name text box present under validator.
6. Only one dropdown list appears showing the components of the selected service 