### PR TITLE
AMBARI-25083. Fallback to use dynamic field 'ws_*' if new field name contains whitespace

### DIFF
--- a/ambari-logsearch-logfeeder-plugin-api/src/main/java/org/apache/ambari/logfeeder/plugin/filter/Filter.java
+++ b/ambari-logsearch-logfeeder-plugin-api/src/main/java/org/apache/ambari/logfeeder/plugin/filter/Filter.java
@@ -215,7 +215,7 @@ public abstract class Filter<PROP_TYPE extends LogFeederProperties> extends Conf
       String name = entry.getKey();
       if (containsWhitespace(name) && name.length() < 100) {
         fieldsToRemove.add(name);
-        name = "ws_" + replaceAll(name.toLowerCase(), " ", "_");
+        name = "ws_" + name.toLowerCase().replaceAll(" ", "_");
         if (!jsonObj.containsKey(name)) {
           fieldValuePairsToAdd.put(name, entry.getValue());
         }
@@ -245,22 +245,7 @@ public abstract class Filter<PROP_TYPE extends LogFeederProperties> extends Conf
           return true;
         }
       }
-
       return false;
     }
-  }
-
-  /**
-   * Replace substring in a string based on regex - similar as StringUtils function in order to not include it as a dependency
-   * @param text string that will be checked
-   * @param regex old value that will be replaced
-   * @param replacement new value
-   * @return character sequence contains whitespace or not
-   */
-  private String replaceAll(final String text, final String regex, final String replacement) {
-    if (text == null || regex == null|| replacement == null ) {
-      return text;
-    }
-    return text.replaceAll(regex, replacement);
   }
 }


### PR DESCRIPTION
# What changes were proposed in this pull request?
add new check for the Filter object (in plugin api), if the field name is not too long and contains spaces, lowercase the string, replaces spaces with underscore, then add ws_ prefix to it, to make a dynamic field from it

note: i added 2 functions that are similar that we have in string utils, but i implemented them in order to not include the dependency in the plugin api

## How was this patch tested?
manually with docker env - added new fields to ambari audit and see what happens
