### PR TITLE
[AMBARI-25028] [Log Search UI] Populate `Component Name` in validator

### DIFF
--- a/ambari-logsearch-web/src/app/modules/shared/components/dropdown-button/dropdown-button.component.html
+++ b/ambari-logsearch-web/src/app/modules/shared/components/dropdown-button/dropdown-button.component.html
@@ -15,16 +15,18 @@
   limitations under the License.
 -->
 
-<div [ngClass]="{'dropup': isDropup, 'has-selection': hasSelection}">
-  <button [ngClass]="['btn', 'dropdown-toggle', buttonClass]" data-toggle="dropdown">
+<div [ngClass]="{ dropup: isDropup, 'has-selection': hasSelection }">
+  <button [ngClass]="['btn', 'dropdown-toggle', buttonClass]" [class.disabled]="disabled" data-toggle="dropdown">
     <span class="filter-label">
       <span *ngIf="iconClass || label" [class.plain]="!isMultipleChoice && !hideCaret && showSelectedValue">
         <span *ngIf="iconClass" [ngClass]="iconClass"></span>
-        <span *ngIf="label && (!hasSelection || isMultipleChoice || showCommonLabelWithSelection)"
-              [class.label-before-selection]="isSelectionDisplayable">
-          {{label}}
+        <span
+          *ngIf="label && (!hasSelection || isMultipleChoice || showCommonLabelWithSelection)"
+          [class.label-before-selection]="isSelectionDisplayable"
+        >
+          {{ label }}
         </span>
-        <span *ngIf="showTotalSelection && totalSelection" class="total-selection badge">{{totalSelection}}</span>
+        <span *ngIf="showTotalSelection && totalSelection" class="total-selection badge">{{ totalSelection }}</span>
       </span>
       <span *ngIf="isSelectionDisplayable">
         <span class="selected-item-label" *ngFor="let item of selectedItems">{{ item.label | translate }}</span>
@@ -32,8 +34,15 @@
       <span *ngIf="!hideCaret" class="caret"></span>
     </span>
   </button>
-  <ul data-component="dropdown-list" (selectedItemChange)="updateSelection($event)"
-    [ngClass]="{'dropdown-menu': true, 'dropdown-menu-right': isRightAlign}" [closeOnSelection]="closeOnSelection"
-    [items]="options" [actionArguments]="listItemArguments" [isMultipleChoice]="isMultipleChoice"
-    [useClearToDefaultSelection]="useClearToDefaultSelection" [useLocalFilter]="useDropDownLocalFilter"></ul>
+  <ul
+    data-component="dropdown-list"
+    (selectedItemChange)="updateSelection($event)"
+    [ngClass]="{ 'dropdown-menu': true, 'dropdown-menu-right': isRightAlign }"
+    [closeOnSelection]="closeOnSelection"
+    [items]="options"
+    [actionArguments]="listItemArguments"
+    [isMultipleChoice]="isMultipleChoice"
+    [useClearToDefaultSelection]="useClearToDefaultSelection"
+    [useLocalFilter]="useDropDownLocalFilter"
+  ></ul>
 </div>

--- a/ambari-logsearch-web/src/app/modules/shared/components/dropdown-button/dropdown-button.component.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/components/dropdown-button/dropdown-button.component.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { ListItem } from '@app/classes/list-item';
 import { UtilsService } from '@app/services/utils.service';
 
@@ -25,8 +25,7 @@ import { UtilsService } from '@app/services/utils.service';
   templateUrl: './dropdown-button.component.html',
   styleUrls: ['./dropdown-button.component.less']
 })
-export class DropdownButtonComponent {
-
+export class DropdownButtonComponent implements OnChanges {
   @Input()
   label?: string;
 
@@ -76,6 +75,9 @@ export class DropdownButtonComponent {
   @Input()
   closeOnSelection = true;
 
+  @Input()
+  disabled = false;
+
   protected selectedItems: ListItem[] = [];
 
   get selection(): ListItem[] {
@@ -83,15 +85,19 @@ export class DropdownButtonComponent {
   }
 
   set selection(items: ListItem[]) {
-    this.selectedItems = <ListItem[]>(Array.isArray(items) ? items : (items || []));
+    this.selectedItems = <ListItem[]>(Array.isArray(items) ? items : items || []);
     if (this.selectedItems.length > 1 && !this.isMultipleChoice) {
       this.selectedItems = this.selectedItems.slice(0, 1);
     }
     if (this.isMultipleChoice && this.options) {
-      this.options.forEach((option: ListItem): void => {
-        const selectionItem = this.selectedItems.find((item: ListItem): boolean => this.utils.isEqual(item.value, option.value));
-        option.isChecked = !!selectionItem;
-      });
+      this.options.forEach(
+        (option: ListItem): void => {
+          const selectionItem = this.selectedItems.find(
+            (item: ListItem): boolean => this.utils.isEqual(item.value, option.value)
+          );
+          option.isChecked = !!selectionItem;
+        }
+      );
     }
   }
 
@@ -113,9 +119,22 @@ export class DropdownButtonComponent {
     return this.showSelectedValue && !this.isMultipleChoice && this.hasSelection;
   }
 
-  constructor(
-    protected utils: UtilsService
-  ) {}
+  get value(): any {
+    const values = this.selectedItems && this.selectedItems.length && this.selectedItems.map(item => item.value);
+    return this.isMultipleChoice ? values : values[0];
+  }
+
+  constructor(protected utils: UtilsService) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.options) {
+      this.hanldeOptionsChange();
+    }
+  }
+
+  hanldeOptionsChange() {
+    this.filterAndSetSelection();
+  }
 
   clearSelection(silent: boolean = false) {
     let hasChange = false;
@@ -128,14 +147,16 @@ export class DropdownButtonComponent {
     }
   }
 
-  updateSelection(updates: ListItem | ListItem[], callOnChange: boolean = true): boolean {
+  updateSelection(updates: ListItem | ListItem[]): boolean {
     let hasChange = false;
     if (updates && (!Array.isArray(updates) || updates.length)) {
       const items: ListItem[] = Array.isArray(updates) ? updates : [updates];
       if (this.isMultipleChoice) {
         items.forEach((item: ListItem) => {
           if (this.options && this.options.length) {
-            const itemToUpdate: ListItem = this.options.find((option: ListItem) => this.utils.isEqual(option.value, item.value));
+            const itemToUpdate: ListItem = this.options.find((option: ListItem) =>
+              this.utils.isEqual(option.value, item.value)
+            );
             if (itemToUpdate) {
               hasChange = hasChange || itemToUpdate.isChecked !== item.isChecked;
               itemToUpdate.isChecked = item.isChecked;
@@ -151,15 +172,18 @@ export class DropdownButtonComponent {
         });
       }
     } else {
-      this.options.forEach((item: ListItem) => item.isChecked = false);
+      this.options.forEach((item: ListItem) => (item.isChecked = false));
     }
-    const checkedItems = this.options.filter((option: ListItem): boolean => option.isChecked);
-    this.selection = checkedItems;
+    this.filterAndSetSelection();
     if (hasChange) {
-      const selectedValues = checkedItems.map((option: ListItem): any => option.value);
+      const selectedValues = this.selection.map((option: ListItem): any => option.value);
       this.selectItem.emit(this.isMultipleChoice ? selectedValues : selectedValues.shift());
     }
     return hasChange;
   }
 
+  protected filterAndSetSelection() {
+    const checkedItems = this.options.filter((option: ListItem): boolean => option.isChecked);
+    this.selection = checkedItems;
+  }
 }

--- a/ambari-logsearch-web/src/app/modules/shared/components/filter-dropdown/filter-dropdown.component.spec.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/components/filter-dropdown/filter-dropdown.component.spec.ts
@@ -15,37 +15,41 @@
  * limitations under the License.
  */
 
-import {NO_ERRORS_SCHEMA} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {MockHttpRequestModules, TranslationModules} from '@app/test-config.spec';
-import {StoreModule} from '@ngrx/store';
-import {AppSettingsService, appSettings} from '@app/services/storage/app-settings.service';
-import {AppStateService, appState} from '@app/services/storage/app-state.service';
-import {AuditLogsService, auditLogs} from '@app/services/storage/audit-logs.service';
-import {AuditLogsFieldsService, auditLogsFields} from '@app/services/storage/audit-logs-fields.service';
-import {AuditLogsGraphDataService, auditLogsGraphData} from '@app/services/storage/audit-logs-graph-data.service';
-import {ServiceLogsService, serviceLogs} from '@app/services/storage/service-logs.service';
-import {ServiceLogsFieldsService, serviceLogsFields} from '@app/services/storage/service-logs-fields.service';
+import { NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockHttpRequestModules, TranslationModules } from '@app/test-config.spec';
+import { StoreModule } from '@ngrx/store';
+import { AppSettingsService, appSettings } from '@app/services/storage/app-settings.service';
+import { AppStateService, appState } from '@app/services/storage/app-state.service';
+import { AuditLogsService, auditLogs } from '@app/services/storage/audit-logs.service';
+import { AuditLogsFieldsService, auditLogsFields } from '@app/services/storage/audit-logs-fields.service';
+import { AuditLogsGraphDataService, auditLogsGraphData } from '@app/services/storage/audit-logs-graph-data.service';
+import { ServiceLogsService, serviceLogs } from '@app/services/storage/service-logs.service';
+import { ServiceLogsFieldsService, serviceLogsFields } from '@app/services/storage/service-logs-fields.service';
 import {
-  ServiceLogsHistogramDataService, serviceLogsHistogramData
+  ServiceLogsHistogramDataService,
+  serviceLogsHistogramData
 } from '@app/services/storage/service-logs-histogram-data.service';
-import {ServiceLogsTruncatedService, serviceLogsTruncated} from '@app/services/storage/service-logs-truncated.service';
-import {TabsService, tabs} from '@app/services/storage/tabs.service';
-import {ClustersService, clusters} from '@app/services/storage/clusters.service';
-import {ComponentsService, components} from '@app/services/storage/components.service';
-import {HostsService, hosts} from '@app/services/storage/hosts.service';
-import {UtilsService} from '@app/services/utils.service';
-import {LogsContainerService} from '@app/services/logs-container.service';
-import {AuthService} from '@app/services/auth.service';
+import {
+  ServiceLogsTruncatedService,
+  serviceLogsTruncated
+} from '@app/services/storage/service-logs-truncated.service';
+import { TabsService, tabs } from '@app/services/storage/tabs.service';
+import { ClustersService, clusters } from '@app/services/storage/clusters.service';
+import { ComponentsService, components } from '@app/services/storage/components.service';
+import { HostsService, hosts } from '@app/services/storage/hosts.service';
+import { UtilsService } from '@app/services/utils.service';
+import { LogsContainerService } from '@app/services/logs-container.service';
+import { AuthService } from '@app/services/auth.service';
 
-import {FilterDropdownComponent} from './filter-dropdown.component';
-import {ClusterSelectionService} from '@app/services/storage/cluster-selection.service';
-import {LogsStateService} from '@app/services/storage/logs-state.service';
-import {RoutingUtilsService} from '@app/services/routing-utils.service';
-import {LogsFilteringUtilsService} from '@app/services/logs-filtering-utils.service';
-import {RouterTestingModule} from '@angular/router/testing';
-import {NotificationService} from '@modules/shared/services/notification.service';
-import {NotificationsService} from 'angular2-notifications/src/notifications.service';
+import { FilterDropdownComponent } from './filter-dropdown.component';
+import { ClusterSelectionService } from '@app/services/storage/cluster-selection.service';
+import { LogsStateService } from '@app/services/storage/logs-state.service';
+import { RoutingUtilsService } from '@app/services/routing-utils.service';
+import { LogsFilteringUtilsService } from '@app/services/logs-filtering-utils.service';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NotificationService } from '@modules/shared/services/notification.service';
+import { NotificationsService } from 'angular2-notifications/src/notifications.service';
 
 import * as auth from '@app/store/reducers/auth.reducers';
 import { EffectsModule } from '@ngrx/effects';
@@ -77,8 +81,7 @@ describe('FilterDropdownComponent', () => {
     const httpClient = {
       get: () => {
         return {
-          subscribe: () => {
-          }
+          subscribe: () => {}
         };
       }
     };
@@ -136,9 +139,8 @@ describe('FilterDropdownComponent', () => {
         NotificationsService,
         NotificationService
       ],
-      schemas: [NO_ERRORS_SCHEMA]
-    })
-    .compileComponents();
+      schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA]
+    }).compileComponents();
   }));
 
   beforeEach(() => {
@@ -150,5 +152,4 @@ describe('FilterDropdownComponent', () => {
   it('should create component', () => {
     expect(component).toBeTruthy();
   });
-
 });

--- a/ambari-logsearch-web/src/app/modules/shared/components/filter-dropdown/filter-dropdown.component.ts
+++ b/ambari-logsearch-web/src/app/modules/shared/components/filter-dropdown/filter-dropdown.component.ts
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-import {Component, forwardRef} from '@angular/core';
-import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {DropdownButtonComponent} from '@modules/shared/components/dropdown-button/dropdown-button.component';
-import {ListItem} from '@app/classes/list-item';
+import { Component, forwardRef, Input } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { DropdownButtonComponent } from '@modules/shared/components/dropdown-button/dropdown-button.component';
+import { ListItem } from '@app/classes/list-item';
 
 @Component({
   selector: 'filter-dropdown',
@@ -33,7 +33,6 @@ import {ListItem} from '@app/classes/list-item';
   ]
 })
 export class FilterDropdownComponent extends DropdownButtonComponent implements ControlValueAccessor {
-
   private onChange;
 
   private _onChange(value) {
@@ -41,6 +40,9 @@ export class FilterDropdownComponent extends DropdownButtonComponent implements 
       this.onChange(value);
     }
   }
+
+  @Input()
+  options: ListItem[] = [];
 
   updateSelection(updates: ListItem | ListItem[], callOnChange: boolean = true): boolean {
     const hasChange = super.updateSelection(updates);
@@ -50,15 +52,18 @@ export class FilterDropdownComponent extends DropdownButtonComponent implements 
     return hasChange;
   }
 
+  hanldeOptionsChange() {
+    super.hanldeOptionsChange();
+    this._onChange(this.selection);
+  }
+
   writeValue(items: ListItem[]) {
-    this.selection = items ? (Array.isArray(items) ? items : [items] ) : [];
+    this.selection = items ? (Array.isArray(items) ? items : [items]) : [];
   }
 
   registerOnChange(callback: any): void {
     this.onChange = callback;
   }
 
-  registerOnTouched() {
-  }
-
+  registerOnTouched() {}
 }

--- a/ambari-logsearch-web/src/app/modules/shipper/components/shipper-configuration/shipper-configuration.component.spec.ts
+++ b/ambari-logsearch-web/src/app/modules/shipper/components/shipper-configuration/shipper-configuration.component.spec.ts
@@ -16,39 +16,45 @@
  * limitations under the License.
  */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import {ShipperConfigurationComponent} from './shipper-configuration.component';
-import {StoreModule} from '@ngrx/store';
-import {auditLogs, AuditLogsService} from '@app/services/storage/audit-logs.service';
-import {serviceLogsTruncated, ServiceLogsTruncatedService} from '@app/services/storage/service-logs-truncated.service';
-import {components, ComponentsService} from '@app/services/storage/components.service';
-import {UtilsService} from '@app/services/utils.service';
-import {tabs, TabsService} from '@app/services/storage/tabs.service';
-import {serviceLogs, ServiceLogsService} from '@app/services/storage/service-logs.service';
-import {hosts, HostsService} from '@app/services/storage/hosts.service';
-import {MockHttpRequestModules, TranslationModules} from '@app/test-config.spec';
-import {ComponentGeneratorService} from '@app/services/component-generator.service';
-import {auditLogsGraphData, AuditLogsGraphDataService} from '@app/services/storage/audit-logs-graph-data.service';
-import {serviceLogsHistogramData, ServiceLogsHistogramDataService} from '@app/services/storage/service-logs-histogram-data.service';
-import {clusters, ClustersService} from '@app/services/storage/clusters.service';
-import {AuditLogsFieldsService, auditLogsFields} from '@app/services/storage/audit-logs-fields.service';
-import {appSettings, AppSettingsService} from '@app/services/storage/app-settings.service';
-import {appState, AppStateService} from '@app/services/storage/app-state.service';
-import {ClusterSelectionService} from '@app/services/storage/cluster-selection.service';
-import {serviceLogsFields, ServiceLogsFieldsService} from '@app/services/storage/service-logs-fields.service';
-import {LogsContainerService} from '@app/services/logs-container.service';
-import {ShipperRoutingModule} from '@modules/shipper/shipper-routing.module';
-import {ShipperClusterServiceListComponent} from '@modules/shipper/components/shipper-cluster-service-list/shipper-cluster-service-list.component';
-import {ShipperServiceConfigurationFormComponent} from '@modules/shipper/components/shipper-service-configuration-form/shipper-service-configuration-form.component';
-import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {TypeaheadModule} from 'ngx-bootstrap';
-import {DisableControlDirective} from '@modules/shared/directives/disable-control.directive';
-import {ModalComponent} from '@modules/shared/components/modal/modal.component';
-import {RouterTestingModule} from '@angular/router/testing';
-import {ShipperClusterServiceListService} from '@modules/shipper/services/shipper-cluster-service-list.service';
-import {ShipperConfigurationService} from '@modules/shipper/services/shipper-configuration.service';
-import {NotificationService} from '@modules/shared/services/notification.service';
-import {NotificationsService} from 'angular2-notifications/src/notifications.service';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ShipperConfigurationComponent } from './shipper-configuration.component';
+import { StoreModule } from '@ngrx/store';
+import { auditLogs, AuditLogsService } from '@app/services/storage/audit-logs.service';
+import {
+  serviceLogsTruncated,
+  ServiceLogsTruncatedService
+} from '@app/services/storage/service-logs-truncated.service';
+import { components, ComponentsService } from '@app/services/storage/components.service';
+import { UtilsService } from '@app/services/utils.service';
+import { tabs, TabsService } from '@app/services/storage/tabs.service';
+import { serviceLogs, ServiceLogsService } from '@app/services/storage/service-logs.service';
+import { hosts, HostsService } from '@app/services/storage/hosts.service';
+import { MockHttpRequestModules, TranslationModules } from '@app/test-config.spec';
+import { ComponentGeneratorService } from '@app/services/component-generator.service';
+import { auditLogsGraphData, AuditLogsGraphDataService } from '@app/services/storage/audit-logs-graph-data.service';
+import {
+  serviceLogsHistogramData,
+  ServiceLogsHistogramDataService
+} from '@app/services/storage/service-logs-histogram-data.service';
+import { clusters, ClustersService } from '@app/services/storage/clusters.service';
+import { AuditLogsFieldsService, auditLogsFields } from '@app/services/storage/audit-logs-fields.service';
+import { appSettings, AppSettingsService } from '@app/services/storage/app-settings.service';
+import { appState, AppStateService } from '@app/services/storage/app-state.service';
+import { ClusterSelectionService } from '@app/services/storage/cluster-selection.service';
+import { serviceLogsFields, ServiceLogsFieldsService } from '@app/services/storage/service-logs-fields.service';
+import { LogsContainerService } from '@app/services/logs-container.service';
+import { ShipperRoutingModule } from '@modules/shipper/shipper-routing.module';
+import { ShipperClusterServiceListComponent } from '@modules/shipper/components/shipper-cluster-service-list/shipper-cluster-service-list.component';
+import { ShipperServiceConfigurationFormComponent } from '@modules/shipper/components/shipper-service-configuration-form/shipper-service-configuration-form.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { TypeaheadModule } from 'ngx-bootstrap';
+import { DisableControlDirective } from '@modules/shared/directives/disable-control.directive';
+import { ModalComponent } from '@modules/shared/components/modal/modal.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ShipperClusterServiceListService } from '@modules/shipper/services/shipper-cluster-service-list.service';
+import { ShipperConfigurationService } from '@modules/shipper/services/shipper-configuration.service';
+import { NotificationService } from '@modules/shared/services/notification.service';
+import { NotificationsService } from 'angular2-notifications/src/notifications.service';
 
 describe('ShipperConfigurationComponent', () => {
   let component: ShipperConfigurationComponent;
@@ -110,9 +116,9 @@ describe('ShipperConfigurationComponent', () => {
         ShipperServiceConfigurationFormComponent,
         DisableControlDirective,
         ModalComponent
-      ]
-    })
-    .compileComponents();
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/ambari-logsearch-web/src/app/modules/shipper/components/shipper-service-configuration-form/shipper-service-configuration-form.component.html
+++ b/ambari-logsearch-web/src/app/modules/shipper/components/shipper-service-configuration-form/shipper-service-configuration-form.component.html
@@ -14,52 +14,78 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<ng-template #typeAheadTpl let-item="item">
-  {{item | translate}}
-</ng-template>
+<ng-template #typeAheadTpl let-item="item"> {{ item | translate }} </ng-template>
 <div class="container-fluid">
   <div class="row">
     <div class="shipper-form-configuration col-md-6">
       <form [formGroup]="configurationForm" (ngSubmit)="onConfigurationSubmit($event)">
         <fieldset [disabled]="disabled">
-          <h2>{{(serviceName ? 'shipperConfiguration.form.titleEdit' : 'shipperConfiguration.form.titleAdd') | translate}}</h2>
-          <div [ngClass]="{'has-error': serviceNameField.invalid, 'form-group': true}">
+          <h2>
+            {{
+              (serviceName ? 'shipperConfiguration.form.titleEdit' : 'shipperConfiguration.form.titleAdd') | translate
+            }}
+          </h2>
+          <div
+            [ngClass]="{
+              'has-error': serviceNameField.invalid && configurationForm.touched,
+              'form-group': true
+            }"
+          >
             <label>
-              {{'shipperConfiguration.form.serviceLabel' | translate}}
-              <span *ngIf="serviceNameField.errors && serviceNameField.errors.serviceNameExists"
-                    class="help-block validation-block pull-right">
-                {{'shipperConfiguration.form.errors.serviceName.exists' | translate}}
+              {{ 'shipperConfiguration.form.serviceLabel' | translate }}
+              <span
+                *ngIf="serviceNameField.errors && serviceNameField.errors.serviceNameExists"
+                class="help-block validation-block pull-right"
+              >
+                {{ 'shipperConfiguration.form.errors.serviceName.exists' | translate }}
               </span>
-              <span *ngIf="serviceNameField.errors && serviceNameField.errors.required"
-                    class="help-block validation-block pull-right">
-                {{'common.form.errors.required' | translate}}
+              <span
+                *ngIf="serviceNameField.errors && serviceNameField.errors.required"
+                class="help-block validation-block pull-right"
+              >
+                {{ 'common.form.errors.required' | translate }}
               </span>
             </label>
-            <input *ngIf="!serviceName" formControlName="serviceName" class="form-control">
+            <input *ngIf="!serviceName" formControlName="serviceName" class="form-control" />
             <ng-container *ngIf="serviceName">
-              <div class="shipper-configuration-service-name">{{serviceName}}</div>
-              <input type="hidden" name="serviceName" formControlName="serviceName">
+              <div class="shipper-configuration-service-name">{{ serviceName }}</div>
+              <input type="hidden" name="serviceName" formControlName="serviceName" />
             </ng-container>
           </div>
-          <input type="hidden" name="clusterName" formControlName="clusterName">
-          <div [ngClass]="{'has-error': configurationField.invalid, 'form-group': true}">
+          <input type="hidden" name="clusterName" formControlName="clusterName" />
+          <div
+            [ngClass]="{
+              'has-error': configurationField.invalid,
+              'form-group': true
+            }"
+          >
             <label>
-              {{'shipperConfiguration.form.configurationJSONLabel' | translate}}
-              <span *ngIf="configurationField.errors && configurationField.errors.invalidJSON"
-                    class="help-block validation-block pull-right">
-                {{'shipperConfiguration.form.errors.configuration.invalidJSON' | translate}}
+              {{ 'shipperConfiguration.form.configurationJSONLabel' | translate }}
+              <span
+                *ngIf="configurationField.errors && configurationField.errors.invalidJSON"
+                class="help-block validation-block pull-right"
+              >
+                {{ 'shipperConfiguration.form.errors.configuration.invalidJSON' | translate }}
               </span>
-              <span *ngIf="configurationField.errors && configurationField.errors.required"
-                    class="help-block validation-block pull-right">
-                {{'common.form.errors.required' | translate}}
+              <span
+                *ngIf="configurationField.errors && configurationField.errors.required"
+                class="help-block validation-block pull-right"
+              >
+                {{ 'common.form.errors.required' | translate }}
               </span>
             </label>
-            <textarea class="form-control configuration" name="configuration"
-              formControlName="configuration"></textarea>
+            <textarea
+              class="form-control configuration"
+              name="configuration"
+              formControlName="configuration"
+            ></textarea>
           </div>
-          <button class="btn btn-primary pull-right" type="submit"
-                  [disabled]="(!configurationForm.valid || configurationForm.pristine)">
-            {{'shipperConfiguration.form.saveBtn.label' | translate}}
+          <button
+            class="btn btn-primary pull-right"
+            type="submit"
+            [disabled]="!configurationForm.valid || configurationForm.pristine"
+          >
+            {{ 'shipperConfiguration.form.saveBtn.label' | translate }}
           </button>
         </fieldset>
       </form>
@@ -68,47 +94,67 @@
       <div class="container-fluid">
         <div class="row">
           <form [formGroup]="validatorForm" (ngSubmit)="onValidationSubmit($event)">
-            <h2>{{'shipperConfiguration.validator.title' | translate}}</h2>
-            <input type="hidden" name="clusterName" formControlName="clusterName">
+            <h2>{{ 'shipperConfiguration.validator.title' | translate }}</h2>
+            <input type="hidden" name="clusterName" formControlName="clusterName" />
             <div class="form-group" [class.has-warning]="componentNameField.invalid">
               <label>
-                {{'shipperConfiguration.validator.componentNameLabel' | translate}}
-                <span [class.hide]="!componentNameField.errors || !componentNameField.errors.required"
-                      class="help-block validation-block pull-right">
-                  {{'common.form.errors.required' | translate}}
+                <span
+                  [class.hide]="
+                    !componentNameField.errors || !componentNameField.errors.required || configurationForm.invalid
+                  "
+                  class="help-block validation-block pull-right"
+                >
+                  {{ 'common.form.errors.required' | translate }}
                 </span>
-                <span [class.hide]="!componentNameField.value || !componentNameField.errors || !componentNameField.errors.serviceNameDoesNotExistInConfiguration"
-                      class="help-block validation-block pull-right">
-                  {{'shipperConfiguration.form.errors.componentNameField.serviceNameDoesNotExistInConfiguration' | translate}}
+                <span
+                  [class.hide]="
+                    !componentNameField.value ||
+                    !componentNameField.errors ||
+                    !componentNameField.errors.serviceNameDoesNotExistInConfiguration
+                  "
+                  class="help-block validation-block pull-right"
+                >
+                  {{
+                    'shipperConfiguration.form.errors.componentNameField.serviceNameDoesNotExistInConfiguration'
+                      | translate
+                  }}
                 </span>
               </label>
-              <input class="form-control component-name" name="componentName" formControlName="componentName"
-                     [typeahead]="configurationComponents$ | async"
-                     [typeaheadItemTemplate]="typeAheadTpl"
-                     [typeaheadMinLength]="0"
-                     [disableControl]="configurationForm.invalid"
-                     autocomplete="off">
+              <filter-dropdown
+                [options]="configurationComponentsList$ | async"
+                formControlName="componentName"
+                [label]="'shipperConfiguration.validator.componentNameLabel' | translate"
+                [showCommonLabelWithSelection]="true"
+                [disabled]="configurationForm.invalid || !(configurationComponentsList$ | async).length"
+              ></filter-dropdown>
             </div>
             <div class="form-group" [class.has-warning]="sampleDataField.invalid">
               <label>
-                {{'shipperConfiguration.validator.sampleDataLabel' | translate}}
-                <span [class.hide]="!sampleDataField.errors || !sampleDataField.errors.required"
-                      class="help-block validation-block pull-right">
-                  {{'common.form.errors.required' | translate}}
+                {{ 'shipperConfiguration.validator.sampleDataLabel' | translate }}
+                <span
+                  [class.hide]="!sampleDataField.errors || !sampleDataField.errors.required"
+                  class="help-block validation-block pull-right"
+                >
+                  {{ 'common.form.errors.required' | translate }}
                 </span>
               </label>
-              <textarea class="form-control sample-data" name="sampleData" formControlName="sampleData"
-                        [disableControl]="configurationForm.invalid"></textarea>
+              <textarea
+                class="form-control sample-data"
+                name="sampleData"
+                formControlName="sampleData"
+                [disableControl]="configurationForm.invalid"
+              ></textarea>
             </div>
             <div *ngIf="validationResponse" class="form-group">
-              <label>
-                {{'shipperConfiguration.validator.result' | translate}}
-              </label>
-              <pre>{{validationResponse | json}}</pre>
+              <label> {{ 'shipperConfiguration.validator.result' | translate }} </label>
+              <pre>{{ validationResponse | json }}</pre>
             </div>
-            <button class="btn btn-default pull-right" type="submit"
-                    [disabled]="(!validatorForm.valid)">
-              <i class="fa fa-table" aria-hidden="true"></i> {{'shipperConfiguration.form.testBtn.label' | translate}}
+            <button
+              class="btn btn-default pull-right"
+              type="submit"
+              [disabled]="validatorForm.invalid || configurationForm.invalid"
+            >
+              <i class="fa fa-table" aria-hidden="true"></i> {{ 'shipperConfiguration.form.testBtn.label' | translate }}
             </button>
           </form>
         </div>
@@ -116,8 +162,14 @@
     </div>
   </div>
 </div>
-<modal *ngIf="isLeavingDirtyForm" (submit)="leaveDirtyFormConfirmed()" (cancel)="leaveDirtyFormCancelled()"
-       (close)="leaveDirtyFormCancelled()" showCloseButton="false" isSmallModal="true"
-       title="{{'shipperConfiguration.form.leavingDirty.title' | translate}}"
-       bodyText="{{'shipperConfiguration.form.leavingDirty.message' | translate}}">
+<modal
+  *ngIf="isLeavingDirtyForm"
+  (submit)="leaveDirtyFormConfirmed()"
+  (cancel)="leaveDirtyFormCancelled()"
+  (close)="leaveDirtyFormCancelled()"
+  showCloseButton="false"
+  isSmallModal="true"
+  title="{{ 'shipperConfiguration.form.leavingDirty.title' | translate }}"
+  bodyText="{{ 'shipperConfiguration.form.leavingDirty.message' | translate }}"
+>
 </modal>

--- a/ambari-logsearch-web/src/app/modules/shipper/components/shipper-service-configuration-form/shipper-service-configuration-form.component.less
+++ b/ambari-logsearch-web/src/app/modules/shipper/components/shipper-service-configuration-form/shipper-service-configuration-form.component.less
@@ -16,39 +16,51 @@
  * limitations under the License.
  */
 
-@import "../../../shared/forms";
-
-textarea {
-  @extend input.form-control
-  min-height: 5em;
-  resize: vertical;
-  width: 100%;
-  &.validation-result,
-  &.configuration {
-    min-height: 30em;
+@import '../../../shared/forms';
+:host {
+  textarea {
+    &:extend(input.form-control);
+    min-height: 5em;
+    resize: vertical;
+    width: 100%;
+    &.validation-result,
+    &.configuration {
+      min-height: 30em;
+    }
+    &.sample-data {
+      min-height: 8em;
+    }
   }
-  &.sample-data {
-    min-height: 8em;
+  label {
+    width: 100%;
   }
-}
-label {
-  width: 100%;
-}
-.help-block.validation-block {
-  display: none;
-  font-size: .9em;
-  margin: 0;
-  opacity: 0;
-  transition: all 1s ease-in;
-}
-.has-error, .has-warning {
   .help-block.validation-block {
-    display: inline-block;
-    opacity: 1;
+    display: none;
+    font-size: 0.9em;
+    margin: 0;
+    opacity: 0;
+    transition: all 1s ease-in;
   }
-}
+  .has-error,
+  .has-warning {
+    .help-block.validation-block {
+      display: inline-block;
+      opacity: 1;
+    }
+  }
 
-.shipper-form-configuration {
-  background-color: @main-background-color;
-  padding-bottom: 4em;
+  .shipper-form-configuration {
+    background-color: @main-background-color;
+    padding-bottom: 4em;
+  }
+
+  /deep/ filter-dropdown {
+    button,
+    button:focus {
+      padding: 0;
+      .label-before-selection {
+        font-weight: bold;
+      }
+    }
+  }
 }

--- a/ambari-logsearch-web/src/app/modules/shipper/directives/validator.directive.ts
+++ b/ambari-logsearch-web/src/app/modules/shipper/directives/validator.directive.ts
@@ -16,46 +16,49 @@
  * limitations under the License.
  */
 
-import {AbstractControl, ValidatorFn} from '@angular/forms';
-import {ShipperClusterService} from '@modules/shipper/models/shipper-cluster-service.type';
-import {ValidationErrors} from '@angular/forms/src/directives/validators';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import { AbstractControl, ValidatorFn } from '@angular/forms';
+import { ShipperClusterService } from '@modules/shipper/models/shipper-cluster-service.type';
+import { ValidationErrors } from '@angular/forms/src/directives/validators';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 export function configurationValidator(): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     try {
-      const json: {[key: string]: any} = JSON.parse(control.value);
+      const json: { [key: string]: any } = JSON.parse(control.value);
       return null;
     } catch (error) {
       return {
-        invalidJSON: {value: control.value}
+        invalidJSON: { value: control.value }
       };
     }
   };
 }
 
-export function uniqueServiceNameValidator(
-  serviceNames: BehaviorSubject<ShipperClusterService[]>
-): ValidatorFn {
+export function uniqueServiceNameValidator(serviceNames: BehaviorSubject<ShipperClusterService[]>): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     const services: ShipperClusterService[] = serviceNames.getValue();
-    return services && services.indexOf(control.value) > -1 ? {
-      serviceNameExists: {value: control.value}
-    } : null;
+    return services && services.indexOf(control.value) > -1
+      ? {
+          serviceNameExists: { value: control.value }
+        }
+      : null;
   };
 }
 
-export function getConfigurationServiceValidator(configControl: AbstractControl): ValidatorFn {
+export function getConfigurationServiceValidator(configControl: AbstractControl, valueMapper?: Function): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     let components: string[];
     try {
-      const inputs: {[key: string]: any}[] = (configControl.value ? JSON.parse(configControl.value) : {}).input;
+      const inputs: { [key: string]: any }[] = (configControl.value ? JSON.parse(configControl.value) : {}).input;
       components = inputs && inputs.length ? inputs.map(input => input.type) : [];
     } catch (error) {
       components = [];
     }
-    return components.length && components.indexOf(control.value) === -1 ? {
-      serviceNameDoesNotExistInConfiguration: {value: control.value}
-    } : null;
+    const value = valueMapper ? valueMapper(control.value) : control.value;
+    return components.length && components.indexOf(value) === -1
+      ? {
+          serviceNameDoesNotExistInConfiguration: { value: value }
+        }
+      : null;
   };
 }

--- a/docs/cloud_mode.md
+++ b/docs/cloud_mode.md
@@ -15,6 +15,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-### Log Feeder: cloud mode
+### Log Feeder: Cloud Mode
 
-TODO
+Log Feeder is responsible to ship logs to cloud storage. In Log Search case, it is a search engine (Solr), and that can be used by Log Search server to visualize logs.
+Although there is a way to send logs to cloud storage / HDFS as well, of course in that case Solr is not used, so you won't be able to visualize the data. Log Feeder has 3 main modes:
+
+- `DEFAULT`: logs are shipped to Solr (or whatever is configured as output)
+- `CLOUD`: logs are shipped to Cloud storage or HDFS (logs as text files, or in json format)
+- `HYBRID`: logs are shipped to Solr and Cloud storage (or HDFS) as well (parallel mode) 
+
+The cloud mode can be set by `logfeeder.cloud.storage.mode` property in `logfeeder.properties`.
+
+#### How it works ?
+
+In cloud mode, instead of shipping monitored logs to a specific location (directly) like into Solr, first it will ship the all monitored logs to new files to a temporal folder. Those logs are archived periodically, (you can check the configuration options about the log rollover in [logfeeder.properties](#logfeeder_properties.md) with `logfeeder.cloud.rollover.*` prefixes) and in every minutes, there is a background thread that will try to upload those archived logs to HDFS or cloud storage. 
+
+HDFS client is responsible to do the upload and you can provide a `core-site.xml` on the classpath (the HDFS client can be configured to use different filesystems like s3a,wasb,gcs etc.), but if you do not have any `core-site.xml` on the classpath, you can provide `fs.*` properties in `logfeeder.properties` configuration. 
+
+It is common, on specific clusters, there are both HDFS and cloud storage are used, so it is not valid to use the same filesystem that `core-site.xml` uses, that is why we need an option to override the filesystem valide (`fs.defaultFS`), that property is `logfeeder.cloud.storage.base.path` (e.g.: `s3a://mybucket/my/path`)
+
+Overall - as a minimum - it is enough to provide this 2 properties to enable cloud storage mode:
+
+- `logfeeder.cloud.storage.mode`: CLOUD
+- `logfeeder.cloud.storage.base.path`: s3a://mybucket/apps/logsearch


### PR DESCRIPTION
# What changes were proposed in this pull request?

Instead of using text input for the `Component Name` in validation form, I added a dropdown which is populated from the config JSON from the `Configuration` form.

If the JSON is not valid, or there is no component under the `input` property of the configuration, the dropdown is disabled.

## How was this patch tested?

It was tested manually (because of the changes of the `DropdownComponent` I tested all the screens) and by unit tests:
```
PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 295 of 295 SUCCESS (12.378 secs / 12.256 secs)
✨  Done in 43.39s.
```

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
