### PR TITLE
AMBARI-23456. Make rest api doc generation configureable & doc fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,12 @@ prop-docs: install
 prop-docs-only:
 	$(MAVEN_BINARY) -pl ambari-logsearch-docs clean package exec:java -DskipTests -Djdk.version=$(LOGSEARCH_JAVA_VERSION)
 
+update-rest-api-docs: install
+	$(MAVEN_BINARY) -pl ambari-logsearch-docs clean package exec:java -DskipTests -Djdk.version=$(LOGSEARCH_JAVA_VERSION) -Dgenerate.swagger.yaml=true
+
+update-rest-api-docs-only:
+	$(MAVEN_BINARY) -pl ambari-logsearch-docs clean package exec:java -DskipTests -Djdk.version=$(LOGSEARCH_JAVA_VERSION) -Dgenerate.swagger.yaml=true
+
 update-version:
 	$(MAVEN_BINARY) versions:set-property -Dproperty=revision -DnewVersion=$(new-version) -DgenerateBackupPoms=false
 

--- a/ambari-logsearch-docs/pom.xml
+++ b/ambari-logsearch-docs/pom.xml
@@ -29,6 +29,9 @@
   <url>http://maven.apache.org</url>
   <name>Ambari Logsearch Docs</name>
   <description>Ambari Logsearch Docs</description>
+  <properties>
+    <generate.swagger.yaml>false</generate.swagger.yaml>
+  </properties>
   <build>
     <resources>
       <resource>
@@ -86,6 +89,8 @@
           <arguments>
             <argument>--output-dir</argument>
             <argument>${project.basedir}/../docs</argument>
+            <argument>--generate-rest-api-doc</argument>
+            <argument>${generate.swagger.yaml}</argument>
           </arguments>
         </configuration>
       </plugin>

--- a/ambari-logsearch-docs/src/main/java/org/apache/ambari/logsearch/doc/LogSearchDocumentationGenerator.java
+++ b/ambari-logsearch-docs/src/main/java/org/apache/ambari/logsearch/doc/LogSearchDocumentationGenerator.java
@@ -65,6 +65,7 @@ public class LogSearchDocumentationGenerator {
   private static final String LOGFEEDER_PROPERTIES_TEMPLATE_KEY = "logfeederProperties";
 
   private static final String OUTPUT_DIR_OPTION = "output-dir";
+  private static final String GENERATE_REST_API_DOC = "generate-rest-api-doc";
 
   private static final String LOGSEARCH_PACKAGE = "org.apache.ambari.logsearch";
   private static final String LOGFEEDER_PACKAGE = "org.apache.ambari.logfeeder";
@@ -94,6 +95,12 @@ public class LogSearchDocumentationGenerator {
         .longOpt(OUTPUT_DIR_OPTION)
         .hasArg()
         .required()
+        .type(String.class)
+        .build());
+      options.addOption(Option.builder()
+        .desc("Boolean flag to generate REST API doc")
+        .longOpt(GENERATE_REST_API_DOC)
+        .hasArg()
         .type(String.class)
         .build());
       CommandLineParser parser = new DefaultParser();
@@ -139,10 +146,14 @@ public class LogSearchDocumentationGenerator {
 
       File shipperConfigsOutputFile = Paths.get(outputDir, SHIPPER_CONFIGURATIONS_MARKDOWN_OUTPUT).toFile();
       writeMarkdown(freemarkerConfiguration, SHIPPER_CONFIGURATIONS_MARKDOWN_TEMPLATE_FILE, shipperConfigModels, shipperConfigsOutputFile);
-
-      String swaggerYaml = generateSwaggerYaml();
-      File swaggerYamlFile = Paths.get(outputDir, SWAGGER_API_DOC_FOLDER, SWAGGER_YAML_FILE_NAME).toFile();
-      FileUtils.writeStringToFile(swaggerYamlFile, swaggerYaml, Charset.defaultCharset());
+      if (options.hasLongOption(GENERATE_REST_API_DOC) && "true".equals(cmdLine.getOptionValue(GENERATE_REST_API_DOC))) {
+        System.out.println("REST API DOC re-generation is enabled");
+        String swaggerYaml = generateSwaggerYaml();
+        File swaggerYamlFile = Paths.get(outputDir, SWAGGER_API_DOC_FOLDER, SWAGGER_YAML_FILE_NAME).toFile();
+        FileUtils.writeStringToFile(swaggerYamlFile, swaggerYaml, Charset.defaultCharset());
+      } else {
+        System.out.println("REST API DOC re-generation is disabled");
+      }
     } catch (Exception e) {
       e.printStackTrace();
       System.exit(1);

--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/ServiceLogsResource.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/rest/ServiceLogsResource.java
@@ -151,7 +151,7 @@ public class ServiceLogsResource {
   @Path("/components")
   @Produces({MediaType.APPLICATION_JSON})
   @ApiOperation(GET_COMPONENTS_OD)
-  public ServiceComponentMetadataWrapper getComponents(@QueryParam(LogSearchConstants.REQUEST_PARAM_CLUSTER_NAMES) @Nullable String clusters) {
+  public ServiceComponentMetadataWrapper getComponentsByGet(@QueryParam(LogSearchConstants.REQUEST_PARAM_CLUSTER_NAMES) @Nullable String clusters) {
     return serviceLogsManager.getComponentMetadata(clusters);
   }
 
@@ -160,7 +160,7 @@ public class ServiceLogsResource {
   @Consumes({MediaType.APPLICATION_JSON})
   @Produces({MediaType.APPLICATION_JSON})
   @ApiOperation(GET_COMPONENTS_OD)
-  public ServiceComponentMetadataWrapper getComponents(@Nullable ClusterBodyRequest clusterBodyRequest) {
+  public ServiceComponentMetadataWrapper getComponentsByPost(@Nullable ClusterBodyRequest clusterBodyRequest) {
     return serviceLogsManager.getComponentMetadata(clusterBodyRequest != null ? clusterBodyRequest.getClusters() : null);
   }
 
@@ -356,7 +356,7 @@ public class ServiceLogsResource {
   @Path("/truncated")
   @Produces({MediaType.APPLICATION_JSON})
   @ApiOperation(GET_AFTER_BEFORE_LOGS_OD)
-  public ServiceLogResponse getAfterBeforeLogs(@BeanParam ServiceLogTruncatedQueryRequest request) {
+  public ServiceLogResponse getAfterBeforeLogsByGet(@BeanParam ServiceLogTruncatedQueryRequest request) {
     return serviceLogsManager.getAfterBeforeLogs(request);
   }
 
@@ -365,7 +365,7 @@ public class ServiceLogsResource {
   @Consumes({MediaType.APPLICATION_JSON})
   @Produces({MediaType.APPLICATION_JSON})
   @ApiOperation(GET_AFTER_BEFORE_LOGS_OD)
-  public ServiceLogResponse getAfterBeforeLogs(ServiceLogTruncatedBodyRequest request) {
+  public ServiceLogResponse getAfterBeforeLogsByPost(ServiceLogTruncatedBodyRequest request) {
     return serviceLogsManager.getAfterBeforeLogs(request);
   }
 
@@ -393,7 +393,7 @@ public class ServiceLogsResource {
   @Produces({MediaType.APPLICATION_JSON})
   @ApiOperation(GET_HOST_LOGFILES_OD)
   @ValidateOnExecution
-  public HostLogFilesResponse getHostLogFiles(@Valid @BeanParam HostLogFilesQueryRequest request) {
+  public HostLogFilesResponse getHostLogFilesByGet(@Valid @BeanParam HostLogFilesQueryRequest request) {
     return serviceLogsManager.getHostLogFileData(request);
   }
 
@@ -403,7 +403,7 @@ public class ServiceLogsResource {
   @Produces({MediaType.APPLICATION_JSON})
   @ApiOperation(GET_HOST_LOGFILES_OD)
   @ValidateOnExecution
-  public HostLogFilesResponse getHostLogFiles(@Valid @BeanParam HostLogFilesBodyRequest request) {
+  public HostLogFilesResponse getHostLogFilesByPost(@Valid @BeanParam HostLogFilesBodyRequest request) {
     return serviceLogsManager.getHostLogFileData(request);
   }
 

--- a/docs/api-docs/logsearch-swagger.yaml
+++ b/docs/api-docs/logsearch-swagger.yaml
@@ -1033,52 +1033,6 @@ paths:
           description: "successful operation"
       security:
       - basicAuth: []
-  /service/logs/components:
-    get:
-      tags:
-      - "servicelogs"
-      summary: "Get the list of service components currently active or having data\
-        \ in Solr"
-      description: ""
-      operationId: "getComponents"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "clusters"
-        in: "query"
-        required: false
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ServiceComponentMetadataWrapper"
-      security:
-      - basicAuth: []
-    post:
-      tags:
-      - "servicelogs"
-      summary: "Get the list of service components currently active or having data\
-        \ in Solr"
-      description: ""
-      operationId: "getComponents"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/ClusterBodyRequest"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ServiceComponentMetadataWrapper"
-      security:
-      - basicAuth: []
   /service/logs:
     get:
       tags:
@@ -1319,6 +1273,52 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/GroupListResponse"
+      security:
+      - basicAuth: []
+  /service/logs/components:
+    get:
+      tags:
+      - "servicelogs"
+      summary: "Get the list of service components currently active or having data\
+        \ in Solr"
+      description: ""
+      operationId: "getComponentsByGet"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusters"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ServiceComponentMetadataWrapper"
+      security:
+      - basicAuth: []
+    post:
+      tags:
+      - "servicelogs"
+      summary: "Get the list of service components currently active or having data\
+        \ in Solr"
+      description: ""
+      operationId: "getComponentsByPost"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/ClusterBodyRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ServiceComponentMetadataWrapper"
       security:
       - basicAuth: []
   /service/logs/aggregated:
@@ -2841,7 +2841,7 @@ paths:
       - "servicelogs"
       summary: "Preview feature data"
       description: ""
-      operationId: "getAfterBeforeLogs"
+      operationId: "getAfterBeforeLogsByGet"
       produces:
       - "application/json"
       parameters:
@@ -3010,7 +3010,7 @@ paths:
       - "servicelogs"
       summary: "Preview feature data"
       description: ""
-      operationId: "getAfterBeforeLogs"
+      operationId: "getAfterBeforeLogsByPost"
       consumes:
       - "application/json"
       produces:
@@ -3069,7 +3069,7 @@ paths:
       - "servicelogs"
       summary: "Get the log files of the components of a host"
       description: ""
-      operationId: "getHostLogFiles"
+      operationId: "getHostLogFilesByGet"
       produces:
       - "application/json"
       parameters:
@@ -3100,7 +3100,7 @@ paths:
       - "servicelogs"
       summary: "Get the log files of the components of a host"
       description: ""
-      operationId: "getHostLogFiles"
+      operationId: "getHostLogFilesByPost"
       consumes:
       - "application/json"
       produces:
@@ -3180,50 +3180,6 @@ paths:
               type: "string"
       security:
       - basicAuth: []
-  /shipper/filters/{clusterName}/level:
-    get:
-      tags:
-      - "shipper"
-      summary: "Get log level filter"
-      description: ""
-      operationId: "getLogLevelFilters"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "clusterName"
-        in: "path"
-        required: true
-        type: "string"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/LSServerLogLevelFilterMap"
-      security:
-      - basicAuth: []
-    put:
-      tags:
-      - "shipper"
-      summary: "Update log level filter"
-      description: ""
-      operationId: "setLogLevelFilter"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/LSServerLogLevelFilterMap"
-      - name: "clusterName"
-        in: "path"
-        required: true
-        type: "string"
-      responses:
-        default:
-          description: "successful operation"
-      security:
-      - basicAuth: []
   /shipper/input/{clusterName}/services/{serviceName}:
     get:
       tags:
@@ -3295,6 +3251,50 @@ paths:
         required: true
         type: "string"
       - name: "serviceName"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+      security:
+      - basicAuth: []
+  /shipper/filters/{clusterName}/level:
+    get:
+      tags:
+      - "shipper"
+      summary: "Get log level filter"
+      description: ""
+      operationId: "getLogLevelFilters"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "clusterName"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/LSServerLogLevelFilterMap"
+      security:
+      - basicAuth: []
+    put:
+      tags:
+      - "shipper"
+      summary: "Update log level filter"
+      description: ""
+      operationId: "setLogLevelFilter"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/LSServerLogLevelFilterMap"
+      - name: "clusterName"
         in: "path"
         required: true
         type: "string"
@@ -3447,24 +3447,28 @@ definitions:
       result:
         type: "integer"
         format: "int32"
-      policy:
-        type: "string"
-      reason:
-        type: "string"
       text:
         type: "string"
-      sess:
+      policy:
+        type: "string"
+      reqContext:
         type: "string"
       access:
         type: "string"
-      reqContext:
+      sess:
         type: "string"
       tags:
         type: "array"
         items:
           type: "string"
+      reason:
+        type: "string"
       logType:
         type: "string"
+      proxyUsers:
+        type: "array"
+        items:
+          type: "string"
       action:
         type: "string"
       agent:
@@ -3493,10 +3497,6 @@ definitions:
         type: "string"
       tags_str:
         type: "string"
-      proxyUsers:
-        type: "array"
-        items:
-          type: "string"
       id:
         type: "string"
       type:
@@ -3506,11 +3506,11 @@ definitions:
       _version_:
         type: "integer"
         format: "int64"
+      log_message:
+        type: "string"
       bundle_id:
         type: "string"
       case_id:
-        type: "string"
-      log_message:
         type: "string"
       logfile_line_number:
         type: "integer"
@@ -3814,26 +3814,6 @@ definitions:
         type: "string"
       type:
         type: "string"
-  ComponentMetadata:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      label:
-        type: "string"
-      group:
-        type: "string"
-  ServiceComponentMetadataWrapper:
-    type: "object"
-    properties:
-      groups:
-        type: "object"
-        additionalProperties:
-          type: "string"
-      metadata:
-        type: "array"
-        items:
-          $ref: "#/definitions/ComponentMetadata"
   ServiceLogData:
     type: "object"
     properties:
@@ -3854,11 +3834,11 @@ definitions:
         type: "string"
       group:
         type: "string"
-      ip:
-        type: "string"
       logtime:
         type: "string"
         format: "date-time"
+      ip:
+        type: "string"
       id:
         type: "string"
       file:
@@ -3866,11 +3846,11 @@ definitions:
       _version_:
         type: "integer"
         format: "int64"
+      log_message:
+        type: "string"
       bundle_id:
         type: "string"
       case_id:
-        type: "string"
-      log_message:
         type: "string"
       logfile_line_number:
         type: "integer"
@@ -4015,6 +3995,26 @@ definitions:
         format: "int32"
   LogData:
     type: "object"
+  ComponentMetadata:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      label:
+        type: "string"
+      group:
+        type: "string"
+  ServiceComponentMetadataWrapper:
+    type: "object"
+    properties:
+      groups:
+        type: "object"
+        additionalProperties:
+          type: "string"
+      metadata:
+        type: "array"
+        items:
+          $ref: "#/definitions/ComponentMetadata"
   GraphData:
     type: "object"
     properties:
@@ -4684,39 +4684,6 @@ definitions:
         type: "string"
       clusters:
         type: "string"
-  LSServerLogLevelFilter:
-    type: "object"
-    required:
-    - "defaultLevels"
-    - "hosts"
-    - "label"
-    properties:
-      label:
-        type: "string"
-      hosts:
-        type: "array"
-        items:
-          type: "string"
-      defaultLevels:
-        type: "array"
-        items:
-          type: "string"
-      overrideLevels:
-        type: "array"
-        items:
-          type: "string"
-      expiryTime:
-        type: "string"
-        format: "date-time"
-  LSServerLogLevelFilterMap:
-    type: "object"
-    required:
-    - "filter"
-    properties:
-      filter:
-        type: "object"
-        additionalProperties:
-          $ref: "#/definitions/LSServerLogLevelFilter"
   LSServerConditions:
     type: "object"
     required:
@@ -4828,6 +4795,39 @@ definitions:
           $ref: "#/definitions/LSServerFilter"
   LSServerPostMapValuesList:
     type: "object"
+  LSServerLogLevelFilter:
+    type: "object"
+    required:
+    - "defaultLevels"
+    - "hosts"
+    - "label"
+    properties:
+      label:
+        type: "string"
+      hosts:
+        type: "array"
+        items:
+          type: "string"
+      defaultLevels:
+        type: "array"
+        items:
+          type: "string"
+      overrideLevels:
+        type: "array"
+        items:
+          type: "string"
+      expiryTime:
+        type: "string"
+        format: "date-time"
+  LSServerLogLevelFilterMap:
+    type: "object"
+    required:
+    - "filter"
+    properties:
+      filter:
+        type: "object"
+        additionalProperties:
+          $ref: "#/definitions/LSServerLogLevelFilter"
   SolrCollectionState:
     type: "object"
     properties:


### PR DESCRIPTION
# What changes were proposed in this pull request?
- make rest api doc generation configurable (because every for every doc generation, the result is different)
- some doc fixes: operationId duplications in swagger doc
## How was this patch tested?
update-rest-api-docs
