### PR TITLE
AMBARI-25090 - Logsearch should index keywords without the ending periods(.)

### DIFF
--- a/ambari-logsearch-server/src/main/configsets/audit_logs/conf/managed-schema
+++ b/ambari-logsearch-server/src/main/configsets/audit_logs/conf/managed-schema
@@ -91,7 +91,7 @@
   <field name="ip" type="key_lower_case"/>
   <field name="level" type="key_lower_case"/>
   <field name="logType" type="key_lower_case" multiValued="false"/>
-  <field name="log_message" type="text_ws" multiValued="false" omitNorms="false"/>
+  <field name="log_message" type="text_std_token_lower_case" multiValued="false" omitNorms="false"/>
   <field name="logfile_line_number" type="tint" omitNorms="false"/>
   <field name="logger_name" type="key_lower_case"/>
   <field name="message_md5" type="string" multiValued="false"/>

--- a/ambari-logsearch-server/src/main/configsets/hadoop_logs/conf/managed-schema
+++ b/ambari-logsearch-server/src/main/configsets/hadoop_logs/conf/managed-schema
@@ -97,7 +97,7 @@
   <field name="ip" type="string" multiValued="false"/>
   <field name="level" type="lowercase" multiValued="false"/>
   <field name="line_number" type="tint" omitNorms="false"/>
-  <field name="log_message" type="text_ws" multiValued="false" omitNorms="false"/>
+  <field name="log_message" type="text_general" multiValued="false" omitNorms="false"/>
   <field name="logfile_line_number" type="tint" omitNorms="false"/>
   <field name="logger_name" type="string" multiValued="false"/>
   <field name="logtime" type="tdate" multiValued="false"  docValues="true"/>


### PR DESCRIPTION
# What changes were proposed in this pull request?

Logsearch should index keywords without the ending periods(.).

E.g : Log message : `Caught exception checkIn.`. Message filters were not able to filter the logs with partial text `checkIn` but only with `checkIn.`

## How was this patch tested?

UTs passed

Manually:
1. Deploy Ambari and a cluster: logsearch, ambri infra, zk
2. Login to logsearch ui
3. Search for terms with and without punctuation