### PR TITLE
AMBARI-25595: Update pom.xml to use https while downloading from spring-milestones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <repository>
       <id>spring-milestones</id>
       <name>Spring Milestones</name>
-      <url>http://repo.spring.io/milestone</url>
+      <url>https://repo.spring.io/milestone</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>


### PR DESCRIPTION
Issue:
mvn clean install package throws 403 forbidden error while downloading from spring-milestones

This happens because the repository doesn't support http

Fix:
Replace the repo link to use https