### PR TITLE
AMBARI-25203 Updated jackson-databind to 2.9.8 and boucycastle libs t…

### DIFF
--- a/ambari-logsearch-server/pom.xml
+++ b/ambari-logsearch-server/pom.xml
@@ -597,12 +597,12 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.55</version>
+      <version>1.61</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.55</version>
+      <version>1.61</version>
     </dependency>
     <dependency>
       <groupId>org.apache.ambari</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <compiler.version>3.8.0</compiler.version>
     <ambari-metrics.version>2.7.0.0.0</ambari-metrics.version>
     <logsearch.docker.tag>latest</logsearch.docker.tag>
-    <fasterxml-jackson.version>2.9.5</fasterxml-jackson.version>
+    <fasterxml-jackson.version>2.9.8</fasterxml-jackson.version>
     <log4j2.version>2.11.1</log4j2.version>
     <swagger-ui.version>3.19.0</swagger-ui.version>
   </properties>


### PR DESCRIPTION

# What changes were proposed in this pull request?

AMBARI-25203 Updated jackson-databind to 2.9.8 and boucycastle libs to 1.61 
## How was this patch tested?

only back port for now

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
