### PR TITLE
AMBARI-25405 Remove dependency on com.fasterxml.jackson.core:jackson-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <compiler.version>3.8.0</compiler.version>
     <ambari-metrics.version>2.7.0.0.0</ambari-metrics.version>
     <logsearch.docker.tag>latest</logsearch.docker.tag>
-    <fasterxml-jackson.version>2.9.8</fasterxml-jackson.version>
+    <fasterxml-jackson.version>2.10.0</fasterxml-jackson.version>
     <log4j2.version>2.11.1</log4j2.version>
     <swagger-ui.version>3.19.0</swagger-ui.version>
   </properties>


### PR DESCRIPTION

# What changes were proposed in this pull request?

AMBARI-25405 Remove dependency on com.fasterxml.jackson.core:jackson-databind:2.9.6-2.9.9.1 in Ambari
pom.xml upgrades
