### PR TITLE
AMBARI-25993: logsearch-logfeeder cannot startup due to lake of configuration

### DIFF
--- a/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederMode.java
+++ b/ambari-logsearch-logfeeder/src/main/java/org/apache/ambari/logfeeder/conf/LogFeederMode.java
@@ -40,12 +40,16 @@ public enum LogFeederMode {
   }
 
   public static LogFeederMode fromString(String text) {
-    for (LogFeederMode mode : LogFeederMode.values()) {
-      if (mode.text.equalsIgnoreCase(text)) {
-        return mode;
+    try {
+      for (LogFeederMode mode : LogFeederMode.values()) {
+        if (mode.text.equalsIgnoreCase(text)) {
+          return mode;
+        }
       }
+    } catch (IllegalArgumentException e) {
+      return LogFeederMode.DEFAULT;
     }
-    throw new IllegalArgumentException(String.format("String '%s' cannot be converted to LogFeederMode enum", text));
+    return LogFeederMode.DEFAULT;
   }
 
   public static boolean isCloudStorage(LogFeederMode mode) {


### PR DESCRIPTION
# What changes were proposed in this pull request?
(Please fill in changes proposed in this fix)

logsearch-logfeeder fail to startup and report:
java.lang.IllegalArgumentException: String 'null' cannot be converted to LogFeederMode enum
<img width="600" alt="image" src="https://github.com/apache/ambari-logsearch/assets/12960246/3caf8b72-58cf-4c3b-947f-a75e3c641527">

Due to the lake of configuration item logfeeder.cloud.storage.mode in configuration.
We need to fall back to Default("default") without this configuration, so logfeeder can startup normally.

After the fix, logfeeder startup normally, and can feed log data to logsearch-portal.


## How was this patch tested?
local install and test this fix in local cluster.

<img width="600" alt="image" src="https://github.com/apache/ambari-logsearch/assets/12960246/9105ca8f-d0d6-4c5e-9d07-b1ecc874b190">


(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
