### PR TITLE
AMBARI-25992: logsearch-portal cannot startup due to spring-boot-autoconfigure upgrade

### DIFF
--- a/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SecurityConfig.java
+++ b/ambari-logsearch-server/src/main/java/org/apache/ambari/logsearch/conf/SecurityConfig.java
@@ -58,6 +58,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -199,6 +200,15 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
       ldapContextSource.afterPropertiesSet();
       return ldapContextSource;
     }
+    return null;
+  }
+
+  @Bean
+  public LdapTemplate ldapTemplate() {
+    if (authPropsConfig.isAuthLdapEnabled()) {
+      return new LdapTemplate(ldapContextSource());
+    }
+
     return null;
   }
 


### PR DESCRIPTION
# What changes were proposed in this pull request?
ambari-logsearch-portal server cannot startup.

After spring-boot upgrade from 2.0.6.RELEASE to 2.1.5.RELEASE, due to the change of class LdapAutoConfiguration, spring need the LdapTemplate bean during startup.

The full error log please see issue [AMBARI-25992](https://issues.apache.org/jira/browse/AMBARI-25992).

## How was this patch tested?
local install and test this fix in local cluster.
<img width="600" alt="image" src="https://github.com/apache/ambari-logsearch/assets/12960246/97ef5fa0-d01c-4500-8abe-1d12f9918851">



(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.
